### PR TITLE
use swr for fetching and mutations

### DIFF
--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -5,24 +5,12 @@ import { GrantData } from "~~/services/database/schema";
 import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_GRANT } from "~~/utils/eip712";
 import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 import { notification } from "~~/utils/scaffold-eth";
+import { postMutationFetcher } from "~~/utils/swr";
 
-const reviewGrant = async (
-  url: string,
-  { arg }: { arg: { signer: string; signature: `0x${string}`; action: ProposalStatusType } },
-) => {
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(arg),
-  });
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.error || "Error reviewing grant");
-  }
-  return data;
+type ReqBody = {
+  signer: string;
+  signature: `0x${string}`;
+  action: ProposalStatusType;
 };
 
 export const GrantReview = ({ grant }: { grant: GrantData }) => {
@@ -30,7 +18,7 @@ export const GrantReview = ({ grant }: { grant: GrantData }) => {
   const { signTypedDataAsync, isLoading: isSigningMessage } = useSignTypedData();
   const { trigger: postReviewGrant, isMutating: isPostingNewGrant } = useSWRMutation(
     `/api/grants/${grant.id}/review`,
-    reviewGrant,
+    postMutationFetcher<ReqBody>,
   );
   const { mutate } = useSWRConfig();
   const isLoading = isSigningMessage || isPostingNewGrant;

--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -48,7 +48,7 @@ export const GrantReview = ({ grant }: { grant: GrantData }) => {
 
     let notificationId;
     try {
-      notificationId = notification.loading("Submiting reivew");
+      notificationId = notification.loading("Submitting review");
       await postReviewGrant({ signer: address, signature, action });
       await mutate("/api/grants/review");
       notification.remove(notificationId);

--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -1,0 +1,108 @@
+import { useSWRConfig } from "swr";
+import useSWRMutation from "swr/mutation";
+import { useAccount, useSignTypedData } from "wagmi";
+import { GrantData } from "~~/services/database/schema";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_GRANT } from "~~/utils/eip712";
+import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
+import { notification } from "~~/utils/scaffold-eth";
+
+const reviewGrant = async (
+  url: string,
+  { arg }: { arg: { signer: string; signature: `0x${string}`; action: ProposalStatusType } },
+) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(arg),
+  });
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || "Error reviewing grant");
+  }
+  return data;
+};
+
+export const GrantReview = ({ grant }: { grant: GrantData }) => {
+  const { address } = useAccount();
+  const { signTypedDataAsync, isLoading: isSigningMessage } = useSignTypedData();
+  const { trigger: postReviewGrant, isMutating: isPostingNewGrant } = useSWRMutation(
+    `/api/grants/${grant.id}/review`,
+    reviewGrant,
+  );
+  const { mutate } = useSWRConfig();
+  const isLoading = isSigningMessage || isPostingNewGrant;
+
+  const handleReviewGrant = async (grant: GrantData, action: ProposalStatusType) => {
+    if (!address) {
+      notification.error("Please connect your wallet");
+      return;
+    }
+
+    let signature;
+    try {
+      signature = await signTypedDataAsync({
+        domain: EIP_712_DOMAIN,
+        types: EIP_712_TYPES__REVIEW_GRANT,
+        primaryType: "Message",
+        message: {
+          grantId: grant.id,
+          action: action,
+        },
+      });
+    } catch (e) {
+      console.error("Error signing message", e);
+      notification.error("Error signing message");
+      return;
+    }
+
+    let notificationId;
+    try {
+      notificationId = notification.loading("Submiting reivew");
+      await postReviewGrant({ signer: address, signature, action });
+      await mutate("/api/grants/review");
+      notification.remove(notificationId);
+      notification.success(`Grant reviewed: ${action}`);
+    } catch (error) {
+      notification.error("Error reviewing grant");
+    } finally {
+      if (notificationId) notification.remove(notificationId);
+    }
+  };
+
+  if (grant.status !== PROPOSAL_STATUS.PROPOSED && grant.status !== PROPOSAL_STATUS.SUBMITTED) return null;
+
+  const acceptStatus = grant.status === PROPOSAL_STATUS.PROPOSED ? PROPOSAL_STATUS.APPROVED : PROPOSAL_STATUS.COMPLETED;
+  const acceptLabel = grant.status === PROPOSAL_STATUS.PROPOSED ? "Approve" : "Complete";
+  return (
+    <div className="border p-4 my-4">
+      <h3 className="font-bold">
+        {grant.title}
+        <span className="text-sm text-gray-500 ml-2">({grant.id})</span>
+      </h3>
+      <p>{grant.description}</p>
+      <div className="mt-4">
+        <button
+          className={`bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded ${
+            isLoading ? "opacity-50" : ""
+          }`}
+          onClick={() => handleReviewGrant(grant, acceptStatus)}
+          disabled={isLoading}
+        >
+          {acceptLabel}
+        </button>
+        <button
+          className={`bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded ml-4 ${
+            isLoading ? "opacity-50" : ""
+          }`}
+          onClick={() => handleReviewGrant(grant, PROPOSAL_STATUS.REJECTED)}
+          disabled={isLoading}
+        >
+          Reject
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -1,119 +1,40 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAccount, useSignTypedData } from "wagmi";
+import { GrantReview } from "./_components/GrantReview";
+import useSWR from "swr";
 import { GrantData } from "~~/services/database/schema";
-import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_GRANT } from "~~/utils/eip712";
-import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
+import { PROPOSAL_STATUS } from "~~/utils/grants";
 import { notification } from "~~/utils/scaffold-eth";
 
-const GrantReview = ({
-  grant,
-  reviewGrant,
-}: {
-  grant: GrantData;
-  reviewGrant: (grant: GrantData, action: ProposalStatusType) => void;
-}) => {
-  if (grant.status !== PROPOSAL_STATUS.PROPOSED && grant.status !== PROPOSAL_STATUS.SUBMITTED) return null;
-
-  const acceptStatus = grant.status === PROPOSAL_STATUS.PROPOSED ? PROPOSAL_STATUS.APPROVED : PROPOSAL_STATUS.COMPLETED;
-  const acceptLabel = grant.status === PROPOSAL_STATUS.PROPOSED ? "Approve" : "Complete";
-  return (
-    <div className="border p-4 my-4">
-      <h3 className="font-bold">
-        {grant.title}
-        <span className="text-sm text-gray-500 ml-2">({grant.id})</span>
-      </h3>
-      <p>{grant.description}</p>
-      <div className="mt-4">
-        <button
-          className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
-          onClick={() => reviewGrant(grant, acceptStatus)}
-        >
-          {acceptLabel}
-        </button>
-        <button
-          className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded ml-4"
-          onClick={() => reviewGrant(grant, PROPOSAL_STATUS.REJECTED)}
-        >
-          Reject
-        </button>
-      </div>
-    </div>
-  );
-};
-
 // ToDo. "Protect" with address header or PROTECT with signing the read.
-// ToDo. Loading states (initial, actions, etc)
-// ToDo. Refresh list after action
 const AdminPage = () => {
-  const { address } = useAccount();
-  const [grants, setGrants] = useState<GrantData[]>([]);
-  const { signTypedDataAsync } = useSignTypedData();
-
-  useEffect(() => {
-    const getGrants = async () => {
-      try {
-        const response = await fetch("/api/grants/review");
-        const grants: GrantData[] = (await response.json()).data;
-        setGrants(grants);
-      } catch (error) {
-        notification.error("Error getting grants for review");
-      }
-    };
-
-    getGrants();
-  }, []);
-
-  const reviewGrant = async (grant: GrantData, action: ProposalStatusType) => {
-    let signature;
-    try {
-      signature = await signTypedDataAsync({
-        domain: EIP_712_DOMAIN,
-        types: EIP_712_TYPES__REVIEW_GRANT,
-        primaryType: "Message",
-        message: {
-          grantId: grant.id,
-          action: action,
-        },
-      });
-    } catch (e) {
-      console.error("Error signing message", e);
-      notification.error("Error signing message");
-      return;
-    }
-
-    try {
-      await fetch(`/api/grants/${grant.id}/review`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ signature, signer: address, action }),
-      });
-      notification.success(`Grant reviewed: ${action}`);
-    } catch (error) {
-      notification.error("Error reviewing grant");
-    }
-  };
+  // TODO: Move the response type to a shared location
+  const { data, isLoading } = useSWR<{ data: GrantData[] }>("/api/grants/review", {
+    onError: error => {
+      console.error("Error fetching grants", error);
+      notification.error("Error getting grants data");
+    },
+  });
+  const grants = data?.data;
 
   const completedGrants = grants?.filter(grant => grant.status === PROPOSAL_STATUS.SUBMITTED);
-  const newGrants = grants.filter(grant => grant.status === PROPOSAL_STATUS.PROPOSED);
+  const newGrants = grants?.filter(grant => grant.status === PROPOSAL_STATUS.PROPOSED);
 
   return (
     <div className="container mx-auto max-w-screen-md mt-12">
       <h1 className="text-4xl font-bold">Admin page</h1>
+      {isLoading && <span className="loading loading-spinner "></span>}
       {grants && (
         <>
           <h2 className="font-bold mt-8">Proposals submitted as completed:</h2>
           {completedGrants?.length === 0 && <p>No completed grants</p>}
-          {completedGrants.map(grant => (
-            <GrantReview key={grant.id} grant={grant} reviewGrant={reviewGrant} />
+          {completedGrants?.map(grant => (
+            <GrantReview key={grant.id} grant={grant} />
           ))}
           <h2 className="font-bold mt-8">New grant proposal:</h2>
           {newGrants?.length === 0 && <p>No new grants</p>}
-          {newGrants.map(grant => (
-            <GrantReview key={grant.id} grant={grant} reviewGrant={reviewGrant} />
+          {newGrants?.map(grant => (
+            <GrantReview key={grant.id} grant={grant} />
           ))}
         </>
       )}

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -23,7 +23,7 @@ const AdminPage = () => {
   return (
     <div className="container mx-auto max-w-screen-md mt-12">
       <h1 className="text-4xl font-bold">Admin page</h1>
-      {isLoading && <span className="loading loading-spinner "></span>}
+      {isLoading && <span className="loading loading-spinner"></span>}
       {grants && (
         <>
           <h2 className="font-bold mt-8">Proposals submitted as completed:</h2>

--- a/packages/nextjs/app/api/builders/[builderAddress]/route.ts
+++ b/packages/nextjs/app/api/builders/[builderAddress]/route.ts
@@ -8,7 +8,7 @@ export async function GET(_request: Request, { params }: { params: { builderAddr
     return NextResponse.json(builderData);
   } catch (error) {
     return NextResponse.json(
-      { message: "Internal Server Error" },
+      { error: "Internal Server Error" },
       {
         status: 500,
       },

--- a/packages/nextjs/app/apply/_component/Form.tsx
+++ b/packages/nextjs/app/apply/_component/Form.tsx
@@ -2,16 +2,38 @@
 
 import { useRouter } from "next/navigation";
 import SubmitButton from "./SubmitButton";
+import useSWRMutation from "swr/mutation";
 import { useAccount, useSignTypedData } from "wagmi";
 import { EIP_712_DOMAIN, EIP_712_TYPES__APPLY_FOR_GRANT } from "~~/utils/eip712";
 import { notification } from "~~/utils/scaffold-eth";
 
+// TODO: move to a shared location
+type ReqBody = {
+  title?: string;
+  description?: string;
+  askAmount?: string;
+  signature?: `0x${string}`;
+  signer?: string;
+};
+
 const selectOptions = [0.1, 0.25, 0.5, 1];
+
+const createNewGrant = async (url: string, { arg }: { arg: ReqBody }) => {
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(arg),
+  });
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.error || "Error submitting grant proposal");
+  }
+};
 
 const Form = () => {
   const { address: connectedAddress } = useAccount();
   const { signTypedDataAsync } = useSignTypedData();
   const router = useRouter();
+  const { trigger: postNewGrant } = useSWRMutation("/api/grants/new", createNewGrant);
 
   const clientFormAction = async (formData: FormData) => {
     if (!connectedAddress) {
@@ -20,9 +42,9 @@ const Form = () => {
     }
 
     try {
-      const title = formData.get("title");
-      const description = formData.get("description");
-      const askAmount = formData.get("askAmount");
+      const title = formData.get("title") as string;
+      const description = formData.get("description") as string;
+      const askAmount = formData.get("askAmount") as string;
       if (!title || !description || !askAmount) {
         notification.error("Please fill all the fields");
         return;
@@ -33,21 +55,13 @@ const Form = () => {
         types: EIP_712_TYPES__APPLY_FOR_GRANT,
         primaryType: "Message",
         message: {
-          title: title as string,
-          description: description as string,
-          askAmount: askAmount as string,
+          title: title,
+          description: description,
+          askAmount: askAmount,
         },
       });
 
-      const res = await fetch("/api/grants/new", {
-        method: "POST",
-        body: JSON.stringify({ title, description, askAmount, signature, signer: connectedAddress }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Error submitting grant proposal");
-      }
+      await postNewGrant({ title, description, askAmount, signature, signer: connectedAddress });
 
       notification.success("Proposal submitted successfully!");
       router.push("/");

--- a/packages/nextjs/app/apply/_component/Form.tsx
+++ b/packages/nextjs/app/apply/_component/Form.tsx
@@ -6,6 +6,7 @@ import useSWRMutation from "swr/mutation";
 import { useAccount, useSignTypedData } from "wagmi";
 import { EIP_712_DOMAIN, EIP_712_TYPES__APPLY_FOR_GRANT } from "~~/utils/eip712";
 import { notification } from "~~/utils/scaffold-eth";
+import { postMutationFetcher } from "~~/utils/swr";
 
 // TODO: move to a shared location
 type ReqBody = {
@@ -18,22 +19,11 @@ type ReqBody = {
 
 const selectOptions = [0.1, 0.25, 0.5, 1];
 
-const createNewGrant = async (url: string, { arg }: { arg: ReqBody }) => {
-  const res = await fetch(url, {
-    method: "POST",
-    body: JSON.stringify(arg),
-  });
-  if (!res.ok) {
-    const data = await res.json();
-    throw new Error(data.error || "Error submitting grant proposal");
-  }
-};
-
 const Form = () => {
   const { address: connectedAddress } = useAccount();
   const { signTypedDataAsync } = useSignTypedData();
   const router = useRouter();
-  const { trigger: postNewGrant } = useSWRMutation("/api/grants/new", createNewGrant);
+  const { trigger: postNewGrant } = useSWRMutation("/api/grants/new", postMutationFetcher<ReqBody>);
 
   const clientFormAction = async (formData: FormData) => {
     if (!connectedAddress) {

--- a/packages/nextjs/app/apply/_component/SubmitButton.tsx
+++ b/packages/nextjs/app/apply/_component/SubmitButton.tsx
@@ -8,7 +8,6 @@ import { useBGBuilderData } from "~~/hooks/useBGBuilderData";
 const SubmitButton = () => {
   const { pending } = useFormStatus();
   const { isConnected, address: connectedAddress } = useAccount();
-  // ToDo. We could use builderData from global state
   const { isBuilderPresent, isLoading: isFetchingBuilderData } = useBGBuilderData(connectedAddress);
   const isSubmitDisabled = !isConnected || isFetchingBuilderData || pending || !isBuilderPresent;
 

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -3,8 +3,9 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { RainbowKitCustomConnectButton } from "./scaffold-eth";
+import { useAccount } from "wagmi";
 import { LockClosedIcon } from "@heroicons/react/24/outline";
-import { useGlobalState } from "~~/services/store/store";
+import { useBGBuilderData } from "~~/hooks/useBGBuilderData";
 
 type HeaderMenuLink = {
   label: string;
@@ -26,7 +27,8 @@ export const menuLinks: HeaderMenuLink[] = [
 
 export const HeaderMenuLinks = () => {
   const pathname = usePathname();
-  const builderData = useGlobalState(state => state.builderData);
+  const { address: connectedAddress } = useAccount();
+  const { data: builderData } = useBGBuilderData(connectedAddress);
 
   return (
     <>

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -4,29 +4,16 @@ import { useEffect, useState } from "react";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import { useTheme } from "next-themes";
 import { Toaster } from "react-hot-toast";
-import { WagmiConfig, useAccount } from "wagmi";
+import { SWRConfig } from "swr";
+import { WagmiConfig } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { ProgressBar } from "~~/components/scaffold-eth/ProgressBar";
-import { useBGBuilderData } from "~~/hooks/useBGBuilderData";
-import { useGlobalState } from "~~/services/store/store";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { appChains } from "~~/services/web3/wagmiConnectors";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
-  const { address } = useAccount();
-  const { data } = useBGBuilderData(address);
-
-  const setBuilderData = useGlobalState(state => state.setBuilderData);
-
-  useEffect(() => {
-    if (data?.id) {
-      setBuilderData(data);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setBuilderData, data?.id]);
-
   return (
     <>
       <div className="flex flex-col min-h-screen font-spaceGrotesk">
@@ -38,6 +25,10 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
     </>
   );
 };
+
+async function fetcher(...args: Parameters<typeof fetch>) {
+  return (await fetch(...args)).json();
+}
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
   const { resolvedTheme } = useTheme();
@@ -56,7 +47,9 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
         avatar={BlockieAvatar}
         theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
       >
-        <ScaffoldEthApp>{children}</ScaffoldEthApp>
+        <SWRConfig value={{ fetcher }}>
+          <ScaffoldEthApp>{children}</ScaffoldEthApp>
+        </SWRConfig>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -27,7 +27,12 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
 };
 
 async function fetcher(...args: Parameters<typeof fetch>) {
-  return (await fetch(...args)).json();
+  const res = await fetch(...args);
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || "Error fetching data");
+  }
+  return data;
 }
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -12,6 +12,7 @@ import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { ProgressBar } from "~~/components/scaffold-eth/ProgressBar";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { appChains } from "~~/services/web3/wagmiConnectors";
+import { fetcher } from "~~/utils/swr";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -25,15 +26,6 @@ const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
     </>
   );
 };
-
-async function fetcher(...args: Parameters<typeof fetch>) {
-  const res = await fetch(...args);
-  const data = await res.json();
-  if (!res.ok) {
-    throw new Error(data.error || "Error fetching data");
-  }
-  return data;
-}
 
 export const ScaffoldEthAppWithProviders = ({ children }: { children: React.ReactNode }) => {
   const { resolvedTheme } = useTheme();
@@ -52,7 +44,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
         avatar={BlockieAvatar}
         theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
       >
-        <SWRConfig value={{ fetcher, revalidateOnFocus: false }}>
+        <SWRConfig value={{ fetcher: fetcher, revalidateOnFocus: false }}>
           <ScaffoldEthApp>{children}</ScaffoldEthApp>
         </SWRConfig>
       </RainbowKitProvider>

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -52,7 +52,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
         avatar={BlockieAvatar}
         theme={mounted ? (isDarkMode ? darkTheme() : lightTheme()) : lightTheme()}
       >
-        <SWRConfig value={{ fetcher }}>
+        <SWRConfig value={{ fetcher, revalidateOnFocus: false }}>
           <ScaffoldEthApp>{children}</ScaffoldEthApp>
         </SWRConfig>
       </RainbowKitProvider>

--- a/packages/nextjs/hooks/useBGBuilderData.ts
+++ b/packages/nextjs/hooks/useBGBuilderData.ts
@@ -1,46 +1,15 @@
-import { useEffect, useState } from "react";
-import { BuilderData, BuilderDataResponse } from "~~/services/database/schema";
+import useSWRImmutable from "swr/immutable";
+import { BuilderDataResponse } from "~~/services/database/schema";
 
 export const useBGBuilderData = (address?: string) => {
-  const [data, setData] = useState<BuilderData | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const [isBuilderPresent, setIsBuilderPresent] = useState(false);
+  const {
+    data: responseData,
+    isLoading,
+    error,
+  } = useSWRImmutable<BuilderDataResponse>(address ? `/api/builders/${address}` : null);
 
-  useEffect(() => {
-    if (!address) {
-      setData(null);
-      setError(null);
-      setIsBuilderPresent(false);
-      return;
-    }
-
-    const fetchBuilderData = async () => {
-      setIsLoading(true);
-      try {
-        const response = await fetch(`/api/builders/${address}`);
-        if (!response.ok) {
-          throw new Error("An error occurred while fetching builder data");
-        }
-        const jsonData: BuilderDataResponse = await response.json();
-        if (!jsonData.exists || !jsonData.data) {
-          setData(null);
-          setIsBuilderPresent(false);
-          return;
-        }
-
-        setData(jsonData.data);
-        setIsBuilderPresent(true);
-      } catch (err: any) {
-        setError(err);
-        setIsBuilderPresent(false);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchBuilderData();
-  }, [address]);
+  const data = responseData?.data;
+  const isBuilderPresent = responseData?.exists ?? false;
 
   return { isLoading, error, data, isBuilderPresent };
 };

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -30,6 +30,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.0",
+    "swr": "^2.2.5",
     "use-debounce": "^8.0.4",
     "usehooks-ts": "^2.13.0",
     "viem": "1.19.9",

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -1,6 +1,5 @@
 import { create } from "zustand";
 import scaffoldConfig from "~~/scaffold.config";
-import { BuilderData } from "~~/services/database/schema";
 import { ChainWithAttributes } from "~~/utils/scaffold-eth";
 
 /**
@@ -17,8 +16,6 @@ type GlobalState = {
   setNativeCurrencyPrice: (newNativeCurrencyPriceState: number) => void;
   targetNetwork: ChainWithAttributes;
   setTargetNetwork: (newTargetNetwork: ChainWithAttributes) => void;
-  builderData: BuilderData | null;
-  setBuilderData: (newBuilderData: BuilderData) => void;
 };
 
 export const useGlobalState = create<GlobalState>(set => ({
@@ -26,6 +23,4 @@ export const useGlobalState = create<GlobalState>(set => ({
   setNativeCurrencyPrice: (newValue: number): void => set(() => ({ nativeCurrencyPrice: newValue })),
   targetNetwork: scaffoldConfig.targetNetworks[0],
   setTargetNetwork: (newTargetNetwork: ChainWithAttributes) => set(() => ({ targetNetwork: newTargetNetwork })),
-  builderData: null,
-  setBuilderData: (newBuilderData: BuilderData) => set(() => ({ builderData: newBuilderData })),
 }));

--- a/packages/nextjs/utils/swr.ts
+++ b/packages/nextjs/utils/swr.ts
@@ -1,0 +1,22 @@
+export const fetcher = async (...args: Parameters<typeof fetch>) => {
+  const res = await fetch(...args);
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || "Error fetching data");
+  }
+  return data;
+};
+
+export const postMutationFetcher = async <T = Record<any, any>>(url: string, { arg }: { arg: T }) => {
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(arg),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error || "Error posting data");
+  }
+  return data;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,7 @@ __metadata:
     react-copy-to-clipboard: ^5.1.0
     react-dom: ^18.2.0
     react-hot-toast: ^2.4.0
+    swr: ^2.2.5
     tailwindcss: ^3.3.3
     type-fest: ^4.6.0
     typescript: ^5.1.6
@@ -5725,7 +5726,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"client-only@npm:0.0.1":
+"client-only@npm:0.0.1, client-only@npm:^0.0.1":
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
   checksum: 0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
@@ -14481,6 +14482,18 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
+  languageName: node
+  linkType: hard
+
+"swr@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "swr@npm:2.2.5"
+  dependencies:
+    client-only: ^0.0.1
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0
+  checksum: c6e6a5bd254951b22e5fd0930a95c7f79b5d0657f803c41ba1542cd6376623fb70b1895049d54ddde26da63b91951ae9d62a06772f82be28c1014d421e5b7aa9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

We could completely close this if it seems overpowered for the use case 🙌


Demo video of admin action : 


https://github.com/BuidlGuidl/grants.buidlguidl.com/assets/80153681/ae960780-f0e1-492e-9ccd-e08f7733d7af



### Notes : 

<details>
<summary> 
Notes
</summary>

#### For fetching data `GET` request : 

1. We just need to pass the API endpoint to `useSWR` hook and this also acts as a `key`
2. The `useSWR` will make the GET request with fetch and returns response data along with isLoading, `isError` etc
3. Whever an component mounts it will make the request (we can disbale it by `revalidateOnMount: false` )

eg : 

```ts
const { data, isLoading } = useSWR<{ data: GrantData[] }>("/api/grants/review");
```

#### For `POST`  : 
1. 1st arg Pass the api endpoint 
2. 2nd arg postMutationFetcher utility, (we could also pass body type to as generic)
3. call the trigger function by passing it the body
```ts
const { trigger: postReviewGrant, isMutating: isPostingNewGrant } = useSWRMutation(
  `/api/grants/${grant.id}/review`,
  postMutationFetcher<ReqBody>,
);

// In some async function we can call trigger to make `POST` request : 
await postReviewGrant({ signer: address, signature, action });
await mutate("/api/grants/review");
//  mutate comes from : const { mutate } = useSWRConfig();
```
What this `mutate` function from `useSWRConfig` does is it internally makes the `GET` request for `url`/ `key`  and updates its store maintained for that `key` / `url`

Also notice in demo video although we made `GET` request to `/api/grants/review`  api endpoint after posting review, it didn't show loading spinner and automatically removed the item. __I think__ they achieved this by "mutating" the store for that `key` / `url` properly. Lol I really  this experience


</details>

---

Overall I love the experience and makes life a bit simple(like not creating `useEffects`, `isLoading` etc), but 100% agree it might be a bit overpowered

closes #22 
