### PR TITLE
Submit completed builds

### DIFF
--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -101,6 +101,11 @@ export const GrantReview = ({ grant }: { grant: GrantDataWithBuilder }) => {
       <h3 className="font-bold">
         {grant.title}
         <span className="text-sm text-gray-500 ml-2">({grant.id})</span>
+        {grant.link && (
+          <a href={grant.link} className="ml-4 underline" target="_blank" rel="noopener noreferrer">
+            View Build
+          </a>
+        )}
       </h3>
       <div className="flex gap-4 items-center">
         <a

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -11,7 +11,7 @@ type ReqBody = {
   signature?: `0x${string}`;
 };
 
-// TODO: Maybe we could fetch build from firebase and check if its really present,
+// TODO: Maybe we could fetch submmited build on BG app from firebase and check if its really present,
 // also check that build was actually submitted by the same builder
 export async function POST(req: Request) {
   try {

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -11,6 +11,8 @@ type ReqBody = {
   signature?: `0x${string}`;
 };
 
+// TODO: Maybe we could fetch build from firebase and check if its really present,
+// also check that build was actually submitted by the same builder
 export async function POST(req: Request) {
   try {
     const { grantId, link, signer, signature } = (await req.json()) as ReqBody;

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -19,7 +19,10 @@ export async function POST(req: Request) {
     // Verify if the builder is present
     const builder = await findUserByAddress(signer);
     if (!builder.exists) {
-      return NextResponse.json({ error: "Only buidlguild builders can submit for grants" }, { status: 401 });
+      return NextResponse.json(
+        { error: "Only buidlguild builders can submit their builds for active grants" },
+        { status: 401 },
+      );
     }
 
     const submitBuild = await submitGrantBuild(grantId, link);

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -49,9 +49,9 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Grant is not approved" }, { status: 400 });
     }
 
-    const submitBuild = await submitGrantBuild(grantId, link);
+    await submitGrantBuild(grantId, link);
 
-    return NextResponse.json({ submitBuild }, { status: 201 });
+    return NextResponse.json({}, { status: 201 });
   } catch (e) {
     console.error(e);
     return NextResponse.json({ error: "Error processing form" }, { status: 500 });

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { submitGrantBuild } from "~~/services/database/grants";
+import { findUserByAddress } from "~~/services/database/users";
+
+type ReqBody = {
+  grantId?: string;
+  signer?: string;
+  link?: string;
+};
+
+export async function POST(req: Request) {
+  try {
+    const { grantId, link, signer } = (await req.json()) as ReqBody;
+
+    if (!grantId || !signer || !link) {
+      return NextResponse.json({ error: "Invalid form details submitted" }, { status: 400 });
+    }
+
+    // Verify if the builder is present
+    const builder = await findUserByAddress(signer);
+    if (!builder.exists) {
+      return NextResponse.json({ error: "Only buidlguild builders can submit for grants" }, { status: 401 });
+    }
+
+    const submitBuild = await submitGrantBuild(grantId, link);
+
+    return NextResponse.json({ submitBuild }, { status: 201 });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "Error processing form" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -8,6 +8,7 @@ type ReqBody = {
   link?: string;
 };
 
+// TODO: Check if the grants is owned by the builder
 export async function POST(req: Request) {
   try {
     const { grantId, link, signer } = (await req.json()) as ReqBody;

--- a/packages/nextjs/app/api/grants/submit/route.ts
+++ b/packages/nextjs/app/api/grants/submit/route.ts
@@ -11,8 +11,6 @@ type ReqBody = {
   signature?: `0x${string}`;
 };
 
-// TODO: Maybe we could fetch submmited build on BG app from firebase and check if its really present,
-// also check that build was actually submitted by the same builder
 export async function POST(req: Request) {
   try {
     const { grantId, link, signer, signature } = (await req.json()) as ReqBody;

--- a/packages/nextjs/app/my-grants/_components/SubmitModal.tsx
+++ b/packages/nextjs/app/my-grants/_components/SubmitModal.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { mutate } from "swr";
+import useSWRMutation from "swr/mutation";
+import { useAccount } from "wagmi";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import { notification } from "~~/utils/scaffold-eth";
+import { postMutationFetcher } from "~~/utils/swr";
+
+type ReqBody = {
+  grantId?: string;
+  status?: string;
+  signer?: string;
+  link?: string;
+};
+
+export const SubmitModal = ({
+  grantTitle,
+  grantId,
+  closeModal,
+}: {
+  grantTitle: string;
+  grantId: string;
+  closeModal: () => void;
+}) => {
+  const { address: connectedAddress } = useAccount();
+  const [buildUrl, setBuildUrl] = useState("");
+  const { trigger: submitBuildLink } = useSWRMutation("/api/grants/submit", postMutationFetcher<ReqBody>);
+
+  const handleSubmit = async () => {
+    const urlPattern = new RegExp("^(https://app\\.buidlguidl\\.com/build/)[a-z0-9-]+$");
+
+    if (!urlPattern.test(buildUrl.toLowerCase()))
+      return notification.error("You must submit a valid build URL (https://app.buidlguidl.com/build/...)");
+
+    let notificationId;
+    try {
+      notificationId = notification.loading("Submitting build URL");
+      await submitBuildLink({ grantId: grantId, link: buildUrl, signer: connectedAddress });
+      await mutate(`/api/builders/${connectedAddress}/grants`);
+      closeModal();
+      notification.remove(notificationId);
+      notification.success("Build URL submitted successfully");
+    } catch (error) {
+      notification.error("Error submitting build URL");
+    } finally {
+      if (notificationId) notification.remove(notificationId);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-8 md:p-0 z-10"
+      onClick={closeModal}
+    >
+      <div className="rounded-2xl bg-primary p-5 w-auto md:w-1/2 lg:w-1/3 xl:w-1/4" onClick={e => e.stopPropagation()}>
+        <button onClick={closeModal} className="float-right text-xs hover:underline">
+          Close
+        </button>
+        <h2 className="font-medium text-lg pb-2">{grantTitle}</h2>
+        <div role="alert" className="alert border-0">
+          <span className="text-sm text-gray-400">
+            <InformationCircleIcon
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="2"
+              className="stroke-info shrink-0 w-5 h-5 inline-block mr-2"
+            />
+            First you&apos;ll need to register the build in your&nbsp;
+            <a
+              href={`https://app.buidlguidl.com/builders/${connectedAddress}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-black-500 underline"
+            >
+              BuidlGuidl profile
+            </a>
+            &nbsp;and then submit the URL of your BG build in this form. BG Grants team will review it to complete the
+            grant.
+          </span>
+        </div>
+        <label className="block mt-4">
+          <span className="font-medium">Build URL</span> to be reviewed and complete grant:
+        </label>
+        <input
+          type="text"
+          value={buildUrl}
+          onChange={e => setBuildUrl(e.target.value)}
+          placeholder="https://app.buidlguidl.com/build/..."
+          className="placeholder: pl-[14px] mt-4 w-full p-1 rounded-lg"
+        />
+        <button className="mt-8 btn btn-sm btn-secondary" onClick={handleSubmit}>
+          Submit
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { SetStateAction, useState } from "react";
+import { useState } from "react";
+import { SubmitModal } from "./_components/SubmitModal";
 import { NextPage } from "next";
-import useSWR, { mutate } from "swr";
-import useSWRMutation from "swr/mutation";
+import useSWR from "swr";
 import { useAccount } from "wagmi";
-import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { GrantData } from "~~/services/database/schema";
 import { PROPOSAL_STATUS } from "~~/utils/grants";
-import { notification } from "~~/utils/scaffold-eth";
-import { postMutationFetcher } from "~~/utils/swr";
 
+// TODO: Move this to util
 const badgeBgColor = {
   [PROPOSAL_STATUS.PROPOSED]: "bg-warning",
   [PROPOSAL_STATUS.APPROVED]: "bg-success",
@@ -19,67 +17,18 @@ const badgeBgColor = {
   [PROPOSAL_STATUS.REJECTED]: "bg-error",
 };
 
-type ReqBody = {
-  grantId?: string;
-  status?: string;
-  signer?: string;
-  link?: string;
-};
-
 const MyGrants: NextPage = () => {
   const { address } = useAccount();
   const { data: builderGrants, isLoading } = useSWR<GrantData[]>(address ? `/api/builders/${address}/grants` : null);
-  const { trigger: submitBuildLink } = useSWRMutation("/api/grants/submit", postMutationFetcher<ReqBody>);
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [buildUrl, setBuildUrl] = useState("");
   const [currentGrantId, setCurrentGrantId] = useState("");
-
   const [currentGrantTitle, setCurrentGrantTitle] = useState("");
 
-  const openModal = (grantId: SetStateAction<string>, grantTitle: string) => {
+  const openModal = (grantId: string, grantTitle: string) => {
     setCurrentGrantId(grantId);
     setCurrentGrantTitle(grantTitle);
     setModalIsOpen(true);
-  };
-  const closeModal = () => {
-    setModalIsOpen(false);
-  };
-  const handleBuildUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setBuildUrl(event.target.value);
-  };
-
-  // TODO: check for a better validation in stackoverflow
-  const handleSubmit = async () => {
-    let processedUrl = buildUrl;
-
-    if (!processedUrl.startsWith("http://") && !processedUrl.startsWith("https://")) {
-      processedUrl = "https://" + processedUrl;
-    }
-
-    if (processedUrl.startsWith("http://")) {
-      processedUrl = "https://" + processedUrl.substring(7);
-    }
-
-    const urlPattern = new RegExp("^(https://app\\.buidlguidl\\.com/build/)[a-z0-9-]+$");
-
-    if (urlPattern.test(processedUrl.toLowerCase())) {
-      let notificationId;
-      try {
-        notificationId = notification.loading("Submitting build URL");
-        await submitBuildLink({ grantId: currentGrantId, link: processedUrl, signer: address });
-        mutate(`/api/builders/${address}/grants`);
-        closeModal();
-        notification.remove(notificationId);
-        notification.success("Build URL submitted successfully");
-      } catch (error) {
-        notification.error("Error submitting build URL");
-      } finally {
-        if (notificationId) notification.remove(notificationId);
-      }
-    } else {
-      notification.error("You must submit a valid build URL (https://app.buidlguidl.com/build/...)");
-    }
   };
 
   return (
@@ -104,54 +53,7 @@ const MyGrants: NextPage = () => {
       ))}
 
       {modalIsOpen && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-8 md:p-0 z-10"
-          onClick={closeModal}
-        >
-          <div
-            className="rounded-2xl bg-primary p-5 w-auto md:w-1/2 lg:w-1/3 xl:w-1/4"
-            onClick={e => e.stopPropagation()}
-          >
-            <button onClick={closeModal} className="float-right text-xs hover:underline">
-              Close
-            </button>
-            <h2 className="font-medium text-lg pb-2">{currentGrantTitle}</h2>
-            <div role="alert" className="alert border-0">
-              <span className="text-sm text-gray-400">
-                <InformationCircleIcon
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="2"
-                  className="stroke-info shrink-0 w-5 h-5 inline-block mr-2"
-                />
-                First you&apos;ll need to register the build in your&nbsp;
-                <a
-                  href={`https://app.buidlguidl.com/builders/${address}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-black-500 underline"
-                >
-                  BuidlGuidl profile
-                </a>
-                &nbsp;and then submit the URL of your BG build in this form. BG Grants team will review it to complete
-                the grant.
-              </span>
-            </div>
-            <label className="block mt-4">
-              <span className="font-medium">Build URL</span> to be reviewed and complete grant:
-            </label>
-            <input
-              type="text"
-              value={buildUrl}
-              onChange={handleBuildUrlChange}
-              placeholder="https://app.buidlguidl.com/build/..."
-              className="placeholder: pl-[14px] mt-4 w-full p-1 rounded-lg"
-            />
-            <button className="mt-8 btn btn-sm btn-secondary" onClick={handleSubmit}>
-              Submit
-            </button>
-          </div>
-        </div>
+        <SubmitModal grantTitle={currentGrantTitle} grantId={currentGrantId} closeModal={() => setModalIsOpen(false)} />
       )}
     </div>
   );

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -8,7 +8,6 @@ import { useAccount } from "wagmi";
 import { GrantData } from "~~/services/database/schema";
 import { PROPOSAL_STATUS } from "~~/utils/grants";
 
-// TODO: Move this to util
 const badgeBgColor = {
   [PROPOSAL_STATUS.PROPOSED]: "bg-warning",
   [PROPOSAL_STATUS.APPROVED]: "bg-success",

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -22,12 +22,10 @@ const MyGrants: NextPage = () => {
   const { data: builderGrants, isLoading } = useSWR<GrantData[]>(address ? `/api/builders/${address}/grants` : null);
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [currentGrantId, setCurrentGrantId] = useState("");
-  const [currentGrantTitle, setCurrentGrantTitle] = useState("");
+  const [currentGrant, setCurrentGrant] = useState<GrantData | null>(null);
 
-  const openModal = (grantId: string, grantTitle: string) => {
-    setCurrentGrantId(grantId);
-    setCurrentGrantTitle(grantTitle);
+  const openModal = (grant: GrantData) => {
+    setCurrentGrant(grant);
     setModalIsOpen(true);
   };
 
@@ -45,15 +43,15 @@ const MyGrants: NextPage = () => {
           <p>{grant.description}</p>
           <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
           {grant.status === PROPOSAL_STATUS.APPROVED && (
-            <button onClick={() => openModal(grant.id, grant.title)} className="btn btn-primary float-right">
+            <button onClick={() => openModal(grant)} className="btn btn-primary float-right">
               Submit build
             </button>
           )}
         </div>
       ))}
 
-      {modalIsOpen && (
-        <SubmitModal grantTitle={currentGrantTitle} grantId={currentGrantId} closeModal={() => setModalIsOpen(false)} />
+      {modalIsOpen && currentGrant !== null && (
+        <SubmitModal grant={currentGrant} closeModal={() => setModalIsOpen(false)} />
       )}
     </div>
   );

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -53,22 +53,20 @@ const MyGrants: NextPage = () => {
   const handleSubmit = async () => {
     let processedUrl = buildUrl;
 
-    // Add https:// if it's missing
     if (!processedUrl.startsWith("http://") && !processedUrl.startsWith("https://")) {
       processedUrl = "https://" + processedUrl;
     }
 
-    // Replace http:// with https://
     if (processedUrl.startsWith("http://")) {
       processedUrl = "https://" + processedUrl.substring(7);
     }
 
     const urlPattern = new RegExp("^(https://app\\.buidlguidl\\.com/build/)[a-z0-9-]+$");
+
     if (urlPattern.test(processedUrl.toLowerCase())) {
       let notificationId;
       try {
         notificationId = notification.loading("Submitting build URL");
-        console.log("Submitting build URL:", processedUrl, "for grant:", currentGrantId, "by:", address);
         await submitBuildLink({ grantId: currentGrantId, link: processedUrl, signer: address });
         mutate(`/api/builders/${address}/grants`);
         closeModal();
@@ -118,8 +116,8 @@ const MyGrants: NextPage = () => {
               Close
             </button>
             <h2 className="font-medium text-lg pb-2">{currentGrantTitle}</h2>
-            <div role="alert" className="alert bg-gray-100 border-0">
-              <span className="text-sm text-primary">
+            <div role="alert" className="alert border-0">
+              <span className="text-sm text-gray-400">
                 <InformationCircleIcon
                   fill="none"
                   viewBox="0 0 24 24"

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { SetStateAction, useState } from "react";
 import { NextPage } from "next";
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
+import useSWRMutation from "swr/mutation";
 import { useAccount } from "wagmi";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { GrantData } from "~~/services/database/schema";
 import { PROPOSAL_STATUS } from "~~/utils/grants";
+import { notification } from "~~/utils/scaffold-eth";
+import { postMutationFetcher } from "~~/utils/swr";
 
 const badgeBgColor = {
   [PROPOSAL_STATUS.PROPOSED]: "bg-warning",
@@ -14,10 +19,70 @@ const badgeBgColor = {
   [PROPOSAL_STATUS.REJECTED]: "bg-error",
 };
 
-// ToDo. Action (v1.0 = submit grant after completion)
+type ReqBody = {
+  grantId?: string;
+  status?: string;
+  signer?: string;
+  link?: string;
+};
+
 const MyGrants: NextPage = () => {
   const { address } = useAccount();
   const { data: builderGrants, isLoading } = useSWR<GrantData[]>(address ? `/api/builders/${address}/grants` : null);
+  const { trigger: submitBuildLink } = useSWRMutation("/api/grants/submit", postMutationFetcher<ReqBody>);
+
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [buildUrl, setBuildUrl] = useState("");
+  const [currentGrantId, setCurrentGrantId] = useState("");
+
+  const [currentGrantTitle, setCurrentGrantTitle] = useState("");
+
+  const openModal = (grantId: SetStateAction<string>, grantTitle: string) => {
+    setCurrentGrantId(grantId);
+    setCurrentGrantTitle(grantTitle);
+    setModalIsOpen(true);
+  };
+  const closeModal = () => {
+    setModalIsOpen(false);
+  };
+  const handleBuildUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setBuildUrl(event.target.value);
+  };
+
+  // TODO: check for a better validation in stackoverflow
+  const handleSubmit = async () => {
+    let processedUrl = buildUrl;
+
+    // Add https:// if it's missing
+    if (!processedUrl.startsWith("http://") && !processedUrl.startsWith("https://")) {
+      processedUrl = "https://" + processedUrl;
+    }
+
+    // Replace http:// with https://
+    if (processedUrl.startsWith("http://")) {
+      processedUrl = "https://" + processedUrl.substring(7);
+    }
+
+    const urlPattern = new RegExp("^(https://app\\.buidlguidl\\.com/build/)[a-z0-9-]+$");
+    if (urlPattern.test(processedUrl.toLowerCase())) {
+      let notificationId;
+      try {
+        notificationId = notification.loading("Submitting build URL");
+        console.log("Submitting build URL:", processedUrl, "for grant:", currentGrantId, "by:", address);
+        await submitBuildLink({ grantId: currentGrantId, link: processedUrl, signer: address });
+        mutate(`/api/builders/${address}/grants`);
+        closeModal();
+        notification.remove(notificationId);
+        notification.success("Build URL submitted successfully");
+      } catch (error) {
+        notification.error("Error submitting build URL");
+      } finally {
+        if (notificationId) notification.remove(notificationId);
+      }
+    } else {
+      notification.error("You must submit a valid build URL (https://app.buidlguidl.com/build/...)");
+    }
+  };
 
   return (
     <div className="container mx-auto max-w-screen-md mt-12">
@@ -32,8 +97,62 @@ const MyGrants: NextPage = () => {
           </h3>
           <p>{grant.description}</p>
           <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
+          {grant.status === PROPOSAL_STATUS.APPROVED && (
+            <button onClick={() => openModal(grant.id, grant.title)} className="btn btn-primary float-right">
+              Submit build
+            </button>
+          )}
         </div>
       ))}
+
+      {modalIsOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-8 md:p-0"
+          onClick={closeModal}
+        >
+          <div
+            className="rounded-2xl bg-primary p-5 w-auto md:w-1/2 lg:w-1/3 xl:w-1/4"
+            onClick={e => e.stopPropagation()}
+          >
+            <button onClick={closeModal} className="float-right text-xs">
+              Close
+            </button>
+            <h2 className="font-medium text-lg pb-2">{currentGrantTitle}</h2>
+            <div className="flex flex-col bg-white border-2 border-blue-500 px-2 rounded-lg">
+              <div className="flex items-start">
+                <InformationCircleIcon className="h-[2rem] w-[2rem] mr-2 mt-2" />
+                <p className="text-sm text-gray-400">
+                  First you&apos;ll need to register the build in your&nbsp;
+                  <a
+                    href={`https://app.buidlguidl.com/builders/${address}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-black-500 underline"
+                  >
+                    BuidlGuidl profile
+                  </a>
+                  &nbsp;and then submit the URL of your BG build in this form. BG Grants team will review to complete
+                  the grant.
+                </p>
+              </div>
+            </div>
+
+            <label className="block mt-4">
+              <span className="font-medium">Build URL</span> to be reviewed and complete grant
+            </label>
+            <input
+              type="text"
+              value={buildUrl}
+              onChange={handleBuildUrlChange}
+              placeholder="https://app.buidlguidl.com/build/..."
+              className="placeholder: pl-[14px] mt-4 w-full p-1 rounded-lg"
+            />
+            <button className="mt-8 btn btn-sm btn-secondary" onClick={handleSubmit}>
+              Submit
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -107,38 +107,40 @@ const MyGrants: NextPage = () => {
 
       {modalIsOpen && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-8 md:p-0"
+          className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-8 md:p-0 z-10"
           onClick={closeModal}
         >
           <div
             className="rounded-2xl bg-primary p-5 w-auto md:w-1/2 lg:w-1/3 xl:w-1/4"
             onClick={e => e.stopPropagation()}
           >
-            <button onClick={closeModal} className="float-right text-xs">
+            <button onClick={closeModal} className="float-right text-xs hover:underline">
               Close
             </button>
             <h2 className="font-medium text-lg pb-2">{currentGrantTitle}</h2>
-            <div className="flex flex-col bg-white border-2 border-blue-500 px-2 rounded-lg">
-              <div className="flex items-start">
-                <InformationCircleIcon className="h-[2rem] w-[2rem] mr-2 mt-2" />
-                <p className="text-sm text-gray-400">
-                  First you&apos;ll need to register the build in your&nbsp;
-                  <a
-                    href={`https://app.buidlguidl.com/builders/${address}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-black-500 underline"
-                  >
-                    BuidlGuidl profile
-                  </a>
-                  &nbsp;and then submit the URL of your BG build in this form. BG Grants team will review to complete
-                  the grant.
-                </p>
-              </div>
+            <div role="alert" className="alert bg-gray-100 border-0">
+              <span className="text-sm text-primary">
+                <InformationCircleIcon
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="2"
+                  className="stroke-info shrink-0 w-5 h-5 inline-block mr-2"
+                />
+                First you&apos;ll need to register the build in your&nbsp;
+                <a
+                  href={`https://app.buidlguidl.com/builders/${address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-black-500 underline"
+                >
+                  BuidlGuidl profile
+                </a>
+                &nbsp;and then submit the URL of your BG build in this form. BG Grants team will review it to complete
+                the grant.
+              </span>
             </div>
-
             <label className="block mt-4">
-              <span className="font-medium">Build URL</span> to be reviewed and complete grant
+              <span className="font-medium">Build URL</span> to be reviewed and complete grant:
             </label>
             <input
               type="text"

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -145,3 +145,16 @@ export const getGrantsStats = async () => {
     throw error;
   }
 };
+
+export const submitGrantBuild = async (grantId: string, link: string) => {
+  const status = PROPOSAL_STATUS.SUBMITTED;
+  const grantActionTimeStamp = new Date().getTime();
+  const grantActionTimeStampKey = (status + "At") as `${typeof status}At`;
+
+  try {
+    await grantsCollection.doc(grantId).update({ status, link, [grantActionTimeStampKey]: grantActionTimeStamp });
+  } catch (error) {
+    console.error("Error updating the grant status:", error);
+    throw error;
+  }
+};

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -149,7 +149,6 @@ export const getGrantsStats = async () => {
 export const getGrantById = async (grantId: string) => {
   try {
     const grantSnapshot = await getGrantSnapshotById(grantId);
-    // TODO: Verify if `exists` value is really provided by firebase
     if (!grantSnapshot.exists) {
       return null;
     }

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -5,8 +5,8 @@ import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 
 const firestoreDB = getFirestoreConnector();
 const grantsCollection = firestoreDB.collection("grants");
-// const getGrantsDoc = (id: string) => grantsCollection.doc(id);
-// const getGrantSnapshotById = (id: string) => getGrantsDoc(id).get();
+const getGrantsDoc = (id: string) => grantsCollection.doc(id);
+const getGrantSnapshotById = (id: string) => getGrantsDoc(id).get();
 
 export const createGrant = async (grantData: Omit<GrantData, "id" | "proposedAt" | "status">) => {
   try {
@@ -146,13 +146,27 @@ export const getGrantsStats = async () => {
   }
 };
 
+export const getGrantById = async (grantId: string) => {
+  try {
+    const grantSnapshot = await getGrantSnapshotById(grantId);
+    // TODO: Verify if `exists` value is really provided by firebase
+    if (!grantSnapshot.exists) {
+      return null;
+    }
+    return { id: grantSnapshot.id, ...grantSnapshot.data() } as GrantData;
+  } catch (error) {
+    console.error("Error getting grant by id:", error);
+    throw error;
+  }
+};
+
 export const submitGrantBuild = async (grantId: string, link: string) => {
   const status = PROPOSAL_STATUS.SUBMITTED;
   const grantActionTimeStamp = new Date().getTime();
   const grantActionTimeStampKey = (status + "At") as `${typeof status}At`;
 
   try {
-    await grantsCollection.doc(grantId).update({ status, link, [grantActionTimeStampKey]: grantActionTimeStamp });
+    await getGrantsDoc(grantId).update({ status, link, [grantActionTimeStampKey]: grantActionTimeStamp });
   } catch (error) {
     console.error("Error updating the grant status:", error);
     throw error;

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -19,3 +19,11 @@ export const EIP_712_TYPES__REVIEW_GRANT = {
     { name: "action", type: "string" },
   ],
 } as const;
+
+export const EIP_712_TYPES__SUBMIT_GRANT = {
+  Message: [
+    { name: "grantId", type: "string" },
+    { name: "action", type: "string" },
+    { name: "link", type: "string" },
+  ],
+} as const;


### PR DESCRIPTION
## Description

Tried to follow the same logic than current status changes.

- Created a button with a modal in /my-grants for the user to submit the build of their active grant. Tried different designs, not so happy with it, could ask Andrea for a future iteration.
- Added notifications when submitting, and logic to save `submittedAt` timestamp.
- Added link to grant card in /admin page, not very fancy link, only underlined text to the right of grant title.
- Wanted to use a stackoverflow simple URL validation but did not find any that I was happy with, so is chatgpt crafted. Take a special look at it at the review 👀

Feel free to push any changes that you see necessary, or let me know if you prefer me to do them ♥🙌

Closes #6 