### PR TITLE
Reduced view for completed grants at Homepage + view all button

### DIFF
--- a/packages/nextjs/app/_components/CompletedGrants.tsx
+++ b/packages/nextjs/app/_components/CompletedGrants.tsx
@@ -39,12 +39,10 @@ export const CompletedGrants = async ({ view = "full" }) => {
 
   return (
     <div className="bg-base-100">
-      <div className="container max-w-[95%] lg:max-w-7xl mx-auto py-12 px-4 lg:px-0">
-        <div className="flex flex-col items-center lg:items-start">
-          <div className="text-4xl lg:text-6xl font-ppEditorial mb-6 text-center lg:text-left">
-            Completed grants
-            <Image src="/assets/sparkle.png" alt="sparkle" width={32} height={32} className="inline-block ml-4" />
-          </div>
+      <div className="container flex flex-col justify-center max-w-[95%] lg:max-w-7xl mx-auto py-12 gap-4">
+        <div className="self-center lg:self-start w-fit relative">
+          <h2 className="text-4xl lg:text-6xl text-center lg:text-left font-ppEditorial">Completed grants</h2>
+          <Image className="absolute -top-3 -right-7" src="/assets/sparkle.png" alt="sparkle" width={32} height={32} />
         </div>
         <div
           className={`${

--- a/packages/nextjs/app/_components/CompletedGrants.tsx
+++ b/packages/nextjs/app/_components/CompletedGrants.tsx
@@ -46,7 +46,7 @@ export const CompletedGrants = async ({ view = "full" }) => {
         </div>
         <div
           className={`${
-            view === "reduced" ? "grant-container" : ""
+            view === "reduced" ? "grant-container-rwd" : ""
           } flex flex-col items-center justify-center md:flex-row md:flex-wrap md:items-start gap-6`}
         >
           {grantsToShow.map(grant => (

--- a/packages/nextjs/app/_components/CompletedGrants.tsx
+++ b/packages/nextjs/app/_components/CompletedGrants.tsx
@@ -33,9 +33,9 @@ const CompletedGrantCard = ({ title, description, askAmount, builder, link, comp
   );
 };
 
-export const CompletedGrants = async ({ view = "full" }) => {
+export const CompletedGrants = async ({ reducedView = false }) => {
   const completedGrants = await getAllCompletedGrants();
-  const grantsToShow = view === "reduced" ? completedGrants.slice(0, 8) : completedGrants;
+  const grantsToShow = reducedView ? completedGrants.slice(0, 8) : completedGrants;
 
   return (
     <div className="bg-base-100">
@@ -46,14 +46,14 @@ export const CompletedGrants = async ({ view = "full" }) => {
         </div>
         <div
           className={`${
-            view === "reduced" ? "grant-container-rwd" : ""
+            reducedView ? "grant-container-rwd" : ""
           } flex flex-col items-center justify-center md:flex-row md:flex-wrap md:items-start gap-6`}
         >
           {grantsToShow.map(grant => (
             <CompletedGrantCard key={grant.id} {...grant} />
           ))}
         </div>
-        {view === "reduced" && (
+        {reducedView && (
           <div className="link w-full text-center mt-8 text-lg lg:text-xl">
             <a href="/completed-grants" className="">
               See all completed grants ({completedGrants.length})

--- a/packages/nextjs/app/_components/CompletedGrants.tsx
+++ b/packages/nextjs/app/_components/CompletedGrants.tsx
@@ -32,21 +32,36 @@ const CompletedGrantCard = ({ title, description, askAmount, builder, link, comp
     </div>
   );
 };
-export const CompletedGrants = async () => {
+
+export const CompletedGrants = async ({ view = "full" }) => {
   const completedGrants = await getAllCompletedGrants();
+  const grantsToShow = view === "reduced" ? completedGrants.slice(0, 8) : completedGrants;
 
   return (
     <div className="bg-base-100">
-      <div className="container flex flex-col justify-center max-w-[95%] lg:max-w-7xl mx-auto py-12 gap-4">
-        <div className="self-center lg:self-start w-fit relative">
-          <h2 className="text-4xl lg:text-6xl text-center lg:text-left font-ppEditorial">Completed grants</h2>
-          <Image className="absolute -top-3 -right-7" src="/assets/sparkle.png" alt="sparkle" width={32} height={32} />
+      <div className="container max-w-[95%] lg:max-w-7xl mx-auto py-12 px-4 lg:px-0">
+        <div className="flex flex-col items-center lg:items-start">
+          <div className="text-4xl lg:text-6xl font-ppEditorial mb-6 text-center lg:text-left">
+            Completed grants
+            <Image src="/assets/sparkle.png" alt="sparkle" width={32} height={32} className="inline-block ml-4" />
+          </div>
         </div>
-        <div className="flex flex-col items-center justify-center md:flex-row md:flex-wrap md:items-start gap-6">
-          {completedGrants.map(grant => (
+        <div
+          className={`${
+            view === "reduced" ? "grant-container" : ""
+          } flex flex-col items-center justify-center md:flex-row md:flex-wrap md:items-start gap-6`}
+        >
+          {grantsToShow.map(grant => (
             <CompletedGrantCard key={grant.id} {...grant} />
           ))}
         </div>
+        {view === "reduced" && (
+          <div className="link w-full text-center mt-8 text-lg lg:text-xl">
+            <a href="/completed-grants" className="">
+              See all completed grants ({completedGrants.length})
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/nextjs/app/completed-grants/page.tsx
+++ b/packages/nextjs/app/completed-grants/page.tsx
@@ -1,0 +1,8 @@
+import { CompletedGrants } from "../_components/CompletedGrants";
+import { NextPage } from "next";
+
+const SubmitGrant: NextPage = () => {
+  return <CompletedGrants />;
+};
+
+export default SubmitGrant;

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -12,7 +12,7 @@ const Home = () => {
       <GrantsStats />
       <EcosystemGrants />
       <CommunityGrant />
-      <CompletedGrants view="reduced" />
+      <CompletedGrants reducedView={true} />
       <ActiveGrants />
     </>
   );

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -12,7 +12,7 @@ const Home = () => {
       <GrantsStats />
       <EcosystemGrants />
       <CommunityGrant />
-      <CompletedGrants />
+      <CompletedGrants view="reduced" />
       <ActiveGrants />
     </>
   );

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -30,3 +30,24 @@ p {
 .btn.btn-ghost {
   @apply shadow-none;
 }
+
+/* Hide elements past the 3rd on screens smaller than 768px */
+@media (max-width: 767px) {
+  .grant-container > :nth-child(n + 4) {
+    display: none;
+  }
+}
+
+/* Hide elements past the 4th on screens between 768px and 1024px */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .grant-container > :nth-child(n + 5) {
+    display: none;
+  }
+}
+
+/* Hide elements past the 6th on screens between 1024px and 1284px */
+@media (min-width: 1024px) and (max-width: 1284px) {
+  .grant-container > :nth-child(n + 7) {
+    display: none;
+  }
+}

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -33,21 +33,21 @@ p {
 
 /* Hide elements past the 3rd on screens smaller than 768px */
 @media (max-width: 767px) {
-  .grant-container > :nth-child(n + 4) {
+  .grant-container-rwd > :nth-child(n + 4) {
     display: none;
   }
 }
 
 /* Hide elements past the 4th on screens between 768px and 1024px */
 @media (min-width: 768px) and (max-width: 1023px) {
-  .grant-container > :nth-child(n + 5) {
+  .grant-container-rwd > :nth-child(n + 5) {
     display: none;
   }
 }
 
 /* Hide elements past the 6th on screens between 1024px and 1284px */
 @media (min-width: 1024px) and (max-width: 1284px) {
-  .grant-container > :nth-child(n + 7) {
+  .grant-container-rwd > :nth-child(n + 7) {
     display: none;
   }
 }

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
             "--tooltip-tail": "6px",
           },
           ".link": {
-            textUnderlineOffset: "2px",
+            textUnderlineOffset: "6px",
           },
           ".link:hover": {
             opacity: "80%",


### PR DESCRIPTION
## Description

Added a new page to show all completed grants, and a reduced view (via prop) to show at Homepage.

Reduced view has a max limit of 8 grants, and then manually forcing on every breakdown to load 2 rows of cards, except on mobile where is loading 3 (2 cards felt too little). Couldn't think of an cleaner way to implement, and 8 cards felt huge on mobile-tablet.

In the future we can make a similar approach for Ecosystem impact grants, or go for a carousel there instead if the number feels optimal for it.

Closes #36 