### PR TITLE
Fix/cache prod

### DIFF
--- a/packages/nextjs/app/api/grants/review/route.tsx
+++ b/packages/nextjs/app/api/grants/review/route.tsx
@@ -1,12 +1,11 @@
-import { revalidatePath } from "next/cache";
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getAllGrantsForReview } from "~~/services/database/grants";
 
-export async function GET(request: NextRequest) {
+export const dynamic = "force-dynamic";
+
+export async function GET() {
   try {
-    const path = request.nextUrl.searchParams.get("path");
     const grants = await getAllGrantsForReview();
-    if (path) revalidatePath(path);
     return NextResponse.json({ data: grants });
   } catch (error) {
     return NextResponse.json(

--- a/packages/nextjs/app/api/grants/review/route.tsx
+++ b/packages/nextjs/app/api/grants/review/route.tsx
@@ -1,9 +1,12 @@
-import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
 import { getAllGrantsForReview } from "~~/services/database/grants";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const path = request.nextUrl.searchParams.get("path");
     const grants = await getAllGrantsForReview();
+    if (path) revalidatePath(path);
     return NextResponse.json({ data: grants });
   } catch (error) {
     return NextResponse.json(

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -6,9 +6,9 @@ import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithPro
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
 
-const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
-  ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-  : `http://localhost:${process.env.PORT}`;
+const baseUrl = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : `http://localhost:${process.env.PORT || 3000}`;
 const imageUrl = `${baseUrl}/thumbnail.jpg`;
 
 export const metadata: Metadata = {

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -5,6 +5,8 @@ import { EcosystemGrants } from "./_components/EcosystemGrants";
 import { GrantsStats } from "./_components/GrantsStats";
 import { HomepageHero } from "./_components/HomepageHero";
 
+export const revalidate = 21600; // 6 hours
+
 const Home = () => {
   return (
     <>

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -9,10 +9,10 @@ export const getMetadata = ({
   description: string;
   imageRelativePath?: string;
 }): Metadata => {
-  const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-    : `http://localhost:${process.env.PORT}`;
-  const imageUrl = `${baseUrl}${imageRelativePath}`;
+  const baseUrl = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : `http://localhost:${process.env.PORT || 3000}`;
+  const imageUrl = `${baseUrl}/${imageRelativePath}`;
   return {
     title: title,
     description: description,


### PR DESCRIPTION
### Issue:

NOTE: This only occurs in prod, since there next does caching and build static stuff their.

<details>
  <summary>Demo of admin page not refetching after mutation</summary>

https://github.com/BuidlGuidl/grants.buidlguidl.com/assets/80153681/2eb751a3-ffb1-4e2b-80fb-77abec506bd5

</details>

As we can once I make approve action, things are remaining as it is and not refetching the data.

### Reason for above cause:

GET `/api/grants/review` route handler was static.

- In NextJS app router, route handlers with [GET are by default](https://vercel.com/blog/common-mistakes-with-the-next-js-app-router-and-how-to-fix-them#static-or-dynamic-route-handlers) static.
- Which means we only run `await getAllGrantsForReview()` in that api once in lifetime just during build time. After that `/api/grants/review` just returns the static data (All review grants _present at build time_).

<details>
  <summary>NextJS marking api/grants/review as static during build time</summary>

![Screenshot 2024-03-03 at 3 43 14 PM](https://github.com/BuidlGuidl/grants.buidlguidl.com/assets/80153681/f7dfc56f-4019-45ae-a082-187a2ff86d96)

</details>

### Solution:

We need to opt out of caching for GET `/api/grants/review` route handler.Since we want admin to see updated data as soon as he does mutation.

The way we OPT out of caching for GET is checkout [this in docs](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#opting-out-of-caching).

Hence in a4d0c400cc97b369278f87fd19b1e2cf7284749b we make use of `request` (which makes GET handler as dynamic) and it also `reavalidatePath` `/admin`(which was also static). The example was taken from [here in docs](https://nextjs.org/docs/app/api-reference/functions/revalidatePath#route-handler)
