### PR TITLE
Add contract's txn hash for batch actions

### DIFF
--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -3,12 +3,11 @@ import Image from "next/image";
 import { useReviewGrant } from "../hooks/useReviewGrant";
 import { ActionModal } from "./ActionModal";
 import { parseEther } from "viem";
-import { useSendTransaction } from "wagmi";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import TelegramIcon from "~~/components/assets/TelegramIcon";
 import TwitterIcon from "~~/components/assets/TwitterIcon";
 import { Address } from "~~/components/scaffold-eth";
-import { useTransactor } from "~~/hooks/scaffold-eth";
+import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
 import { GrantDataWithBuilder, SocialLinks } from "~~/services/database/schema";
 import { PROPOSAL_STATUS } from "~~/utils/grants";
 
@@ -49,11 +48,12 @@ type GrantReviewProps = {
 export const GrantReview = ({ grant, selected, toggleSelection }: GrantReviewProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
 
-  const { data: txnHash, sendTransactionAsync } = useSendTransaction({
-    to: grant.builder,
-    value: parseEther((grant.askAmount / 2).toString()),
+  const { data: txResult, writeAsync: splitEqualETH } = useScaffoldContractWrite({
+    contractName: "BGGrants",
+    functionName: "splitETH",
+    args: [undefined, undefined],
   });
-  const sendTx = useTransactor();
+
   const { handleReviewGrant, isLoading } = useReviewGrant(grant);
 
   if (grant.status !== PROPOSAL_STATUS.PROPOSED && grant.status !== PROPOSAL_STATUS.SUBMITTED) return null;
@@ -96,7 +96,10 @@ export const GrantReview = ({ grant, selected, toggleSelection }: GrantReviewPro
           <button
             className={`btn btn-sm btn-neutral ${isLoading ? "opacity-50" : ""}`}
             onClick={async () => {
-              const resHash = await sendTx(sendTransactionAsync);
+              const resHash = await splitEqualETH({
+                args: [[grant.builder], [parseEther((grant.askAmount / 2).toString())]],
+                value: parseEther((grant.askAmount / 2).toString()),
+              });
               // Transactor eats the error, so we need to handle by checking resHash
               if (resHash && modalRef.current) modalRef.current.showModal();
             }}
@@ -115,7 +118,7 @@ export const GrantReview = ({ grant, selected, toggleSelection }: GrantReviewPro
           </button>
         </div>
       </div>
-      <ActionModal ref={modalRef} grant={grant} initialTxLink={txnHash?.hash} />
+      <ActionModal ref={modalRef} grant={grant} initialTxLink={txResult?.hash} />
     </div>
   );
 };

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -51,7 +51,7 @@ const AdminPage = () => {
     args: [undefined],
   });
 
-  const handleBatchClick = async (filteredGrants: GrantDataWithBuilder[], action: "approve" | "complete") => {
+  const handleBatchAction = async (filteredGrants: GrantDataWithBuilder[], action: "approve" | "complete") => {
     const selectedGrantsWithMetaData = filteredGrants.filter(grant => {
       if (action === "approve") return selectedApproveGrants.includes(grant.id);
       return selectedCompleteGrants.includes(grant.id);
@@ -82,7 +82,7 @@ const AdminPage = () => {
               {completedGrants && completedGrants.length !== 0 && (
                 <button
                   className="btn btn-sm btn-primary"
-                  onClick={() => handleBatchClick(completedGrants, "complete")}
+                  onClick={() => handleBatchAction(completedGrants, "complete")}
                   disabled={selectedCompleteGrants.length === 0}
                 >
                   Batch Complete
@@ -105,7 +105,7 @@ const AdminPage = () => {
               {newGrants && newGrants.length !== 0 && (
                 <button
                   className="btn btn-sm btn-primary"
-                  onClick={() => handleBatchClick(newGrants, "approve")}
+                  onClick={() => handleBatchAction(newGrants, "approve")}
                   disabled={selectedApproveGrants.length === 0}
                 >
                   Batch Approve


### PR DESCRIPTION
## Description

Used `splitEqualETH` function from the contract. In future we could add an unequal spilt function but since in mock DB the `askAmount` is same for all grant `0.25`  it works nicely 🙌

probably Closes #56 ? 
