### PR TITLE
Add title and description to apply page

### DIFF
--- a/packages/nextjs/app/apply/page.tsx
+++ b/packages/nextjs/app/apply/page.tsx
@@ -3,7 +3,13 @@ import { NextPage } from "next";
 
 const SubmitGrant: NextPage = () => {
   return (
-    <div className="flex items-center flex-col flex-grow pt-10">
+    <div className="flex items-center flex-col flex-grow text-center pt-10 md:pt-4 px-6">
+      <h1 className="text-3xl sm:text-4xl font-bold mb-4">Apply for a Community Grant</h1>
+      <p className="text-md mb-0 max-w-xl">
+        As a BuidlGuidl member, you can build projects to make a significant impact on the ecosystem, and get
+        sponsorship of up to 1 ETH for it.
+      </p>
+      <p className="text-md pb-6 max-w-xl">We are excited to support your projects to drive the community forward.</p>
       <Form />
     </div>
   );


### PR DESCRIPTION
## Description

To implement #68 thought about 2 possibilities:

- Adding a title and short description to the page, and keep everything in 1 column.
- Change to 2 columns, adding title and description, and also all the info about __Who, Process, Amount__ and __Payment__, and in the 2nd column the Form.

Went for the simplest approach, if you feel it too simple LMK and I'll try another one 🙌

Short description should be reviewed by Palmer or the person that finally reviews all the copys.