### PR TITLE
Admin route (soft) view access

### DIFF
--- a/packages/nextjs/app/api/grants/review/route.tsx
+++ b/packages/nextjs/app/api/grants/review/route.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { recoverTypedDataAddress } from "viem";
 import { getAllGrantsForReview, reviewGrant } from "~~/services/database/grants";
@@ -8,6 +9,21 @@ import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  // Soft check.
+  const reqHeaders = headers();
+  const address = reqHeaders.get("Address");
+
+  if (!address) {
+    console.error("Unauthorized");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const signerData = await findUserByAddress(address);
+  if (signerData.data?.role !== "admin") {
+    console.error("Unauthorized", address);
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const grants = await getAllGrantsForReview();
     return NextResponse.json({ data: grants });


### PR DESCRIPTION
Let's soft-protect the /admin route. Data is not secret anyway, but let's now allow /admin direct access.

As we discussed on https://github.com/BuidlGuidl/grants.buidlguidl.com/pull/18 and https://github.com/BuidlGuidl/grants.buidlguidl.com/pull/17, if we wanted full protection, we could do SIWE + JWT or signed reads. We might want to consider it in the future.

