### PR TITLE
Allow admin to add note

### DIFF
--- a/packages/nextjs/app/admin/_components/ActionModal.tsx
+++ b/packages/nextjs/app/admin/_components/ActionModal.tsx
@@ -47,14 +47,16 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
             className="input input-bordered w-full"
           />
         </div>
-        <div className="w-full flex-col space-y-1">
-          <p className="m-0 font-semibold text-base">Note (optional)</p>
-          <textarea
-            ref={noteInputRef}
-            placeholder={`Note for ${acceptLabel.toLowerCase()}ing this grant`}
-            className="input input-bordered w-full py-2 h-24"
-          />
-        </div>
+        {grant.status === PROPOSAL_STATUS.PROPOSED && (
+          <div className="w-full flex-col space-y-1">
+            <p className="m-0 font-semibold text-base">Note (optional)</p>
+            <textarea
+              ref={noteInputRef}
+              placeholder={`Note for ${acceptLabel.toLowerCase()}ing this grant`}
+              className="input input-bordered w-full py-2 h-24"
+            />
+          </div>
+        )}
         <button
           className={`btn btn-sm btn-success ${isLoading ? "opacity-50" : ""}`}
           onClick={() =>

--- a/packages/nextjs/app/admin/_components/ActionModal.tsx
+++ b/packages/nextjs/app/admin/_components/ActionModal.tsx
@@ -57,7 +57,9 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
         </div>
         <button
           className={`btn btn-sm btn-success ${isLoading ? "opacity-50" : ""}`}
-          onClick={() => handleReviewGrant(acceptStatus, transactionInputRef.current?.value)}
+          onClick={() =>
+            handleReviewGrant(acceptStatus, transactionInputRef?.current?.value, noteInputRef?.current?.value)
+          }
           disabled={isLoading}
         >
           {isLoading && <span className="loading loading-spinner"></span>}

--- a/packages/nextjs/app/admin/_components/ActionModal.tsx
+++ b/packages/nextjs/app/admin/_components/ActionModal.tsx
@@ -3,15 +3,16 @@ import { useReviewGrant } from "../hooks/useReviewGrant";
 import { useNetwork } from "wagmi";
 import { getNetworkColor } from "~~/hooks/scaffold-eth";
 import { GrantData } from "~~/services/database/schema";
-import { PROPOSAL_STATUS } from "~~/utils/grants";
+import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 
 type ActionModalProps = {
   grant: GrantData;
   initialTxLink?: string;
+  action: ProposalStatusType;
 };
 
-export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ grant, initialTxLink }, ref) => {
+export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ grant, initialTxLink, action }, ref) => {
   const transactionInputRef = useRef<HTMLInputElement>(null);
   const noteInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -20,8 +21,8 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
 
   const { handleReviewGrant, isLoading } = useReviewGrant(grant);
 
-  const acceptStatus = grant.status === PROPOSAL_STATUS.PROPOSED ? PROPOSAL_STATUS.APPROVED : PROPOSAL_STATUS.COMPLETED;
-  const acceptLabel = grant.status === PROPOSAL_STATUS.PROPOSED ? "Approve" : "Complete";
+  const actionLabel =
+    action === PROPOSAL_STATUS.REJECTED ? "Reject" : action === PROPOSAL_STATUS.APPROVED ? "Approve" : "Complete";
   return (
     <dialog id="action_modal" className="modal" ref={ref}>
       <div className="modal-box flex flex-col space-y-3">
@@ -30,42 +31,42 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
           <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
         </form>
         <div className="flex justify-between items-center">
-          <p className="font-bold text-lg m-0">{acceptLabel} this grant</p>
+          <p className="font-bold text-lg m-0">{actionLabel} this grant</p>
           {chainWithExtraAttributes && (
             <p className="m-0 text-sm" style={{ color: getNetworkColor(chainWithExtraAttributes, true) }}>
               {chainWithExtraAttributes.name}
             </p>
           )}
         </div>
-        <div className="w-full flex-col space-y-1">
-          <p className="m-0 font-semibold text-base">Transction Hash</p>
-          <input
-            type="text"
-            ref={transactionInputRef}
-            defaultValue={initialTxLink ?? ""}
-            placeholder="Transaction hash"
-            className="input input-bordered w-full"
-          />
-        </div>
-        {grant.status === PROPOSAL_STATUS.PROPOSED && (
+        {action !== PROPOSAL_STATUS.REJECTED && (
+          <div className="w-full flex-col space-y-1">
+            <p className="m-0 font-semibold text-base">Transction Hash</p>
+            <input
+              type="text"
+              ref={transactionInputRef}
+              defaultValue={initialTxLink ?? ""}
+              placeholder="Transaction hash"
+              className="input input-bordered w-full"
+            />
+          </div>
+        )}
+        {(action === PROPOSAL_STATUS.APPROVED || action === PROPOSAL_STATUS.REJECTED) && (
           <div className="w-full flex-col space-y-1">
             <p className="m-0 font-semibold text-base">Note (optional)</p>
             <textarea
               ref={noteInputRef}
-              placeholder={`Note for ${acceptLabel.toLowerCase()}ing this grant`}
+              placeholder={`Note for ${actionLabel.toLowerCase()}ing this grant`}
               className="input input-bordered w-full py-2 h-24"
             />
           </div>
         )}
         <button
           className={`btn btn-sm btn-success ${isLoading ? "opacity-50" : ""}`}
-          onClick={() =>
-            handleReviewGrant(acceptStatus, transactionInputRef?.current?.value, noteInputRef?.current?.value)
-          }
+          onClick={() => handleReviewGrant(action, transactionInputRef?.current?.value, noteInputRef?.current?.value)}
           disabled={isLoading}
         >
           {isLoading && <span className="loading loading-spinner"></span>}
-          {acceptLabel}
+          {actionLabel}
         </button>
       </div>
     </dialog>

--- a/packages/nextjs/app/admin/_components/ActionModal.tsx
+++ b/packages/nextjs/app/admin/_components/ActionModal.tsx
@@ -12,7 +12,8 @@ type ActionModalProps = {
 };
 
 export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ grant, initialTxLink }, ref) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const transactionInputRef = useRef<HTMLInputElement>(null);
+  const noteInputRef = useRef<HTMLTextAreaElement>(null);
 
   const { chain } = useNetwork();
   const chainWithExtraAttributes = chain ? { ...chain, ...NETWORKS_EXTRA_DATA[chain.id] } : undefined;
@@ -36,16 +37,27 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
             </p>
           )}
         </div>
-        <input
-          type="text"
-          ref={inputRef}
-          defaultValue={initialTxLink ?? ""}
-          placeholder="Transaction hash"
-          className="input input-bordered"
-        />
+        <div className="w-full flex-col space-y-1">
+          <p className="m-0 font-semibold text-base">Transction Hash</p>
+          <input
+            type="text"
+            ref={transactionInputRef}
+            defaultValue={initialTxLink ?? ""}
+            placeholder="Transaction hash"
+            className="input input-bordered w-full"
+          />
+        </div>
+        <div className="w-full flex-col space-y-1">
+          <p className="m-0 font-semibold text-base">Note (optional)</p>
+          <textarea
+            ref={noteInputRef}
+            placeholder={`Note for ${acceptLabel.toLowerCase()}ing this grant`}
+            className="input input-bordered w-full py-2 h-24"
+          />
+        </div>
         <button
           className={`btn btn-sm btn-success ${isLoading ? "opacity-50" : ""}`}
-          onClick={() => handleReviewGrant(acceptStatus, inputRef.current?.value)}
+          onClick={() => handleReviewGrant(acceptStatus, transactionInputRef.current?.value)}
           disabled={isLoading}
         >
           {isLoading && <span className="loading loading-spinner"></span>}

--- a/packages/nextjs/app/admin/hooks/useReviewGrant.ts
+++ b/packages/nextjs/app/admin/hooks/useReviewGrant.ts
@@ -13,6 +13,7 @@ type ReqBody = {
   action: ProposalStatusType;
   txHash: string;
   txChainId: string;
+  note: string;
 };
 
 export const useReviewGrant = (grant: GrantData) => {
@@ -27,7 +28,7 @@ export const useReviewGrant = (grant: GrantData) => {
 
   const isLoading = isSigningMessage || isPostingNewGrant;
 
-  const handleReviewGrant = async (action: ProposalStatusType, txnHash = "") => {
+  const handleReviewGrant = async (action: ProposalStatusType, txnHash = "", note = "") => {
     if (!address || !connectedChain) {
       notification.error("Please connect your wallet");
       return;
@@ -44,6 +45,7 @@ export const useReviewGrant = (grant: GrantData) => {
           action: action,
           txHash: txnHash,
           txChainId: connectedChain.id.toString(),
+          note,
         },
       });
     } catch (e) {
@@ -61,6 +63,7 @@ export const useReviewGrant = (grant: GrantData) => {
         action,
         txHash: txnHash,
         txChainId: connectedChain.id.toString(),
+        note,
       });
       await mutate("/api/grants/review");
       notification.remove(notificationId);

--- a/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
+++ b/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { recoverTypedDataAddress } from "viem";
 import { reviewGrant } from "~~/services/database/grants";
 import { findUserByAddress } from "~~/services/database/users";
-import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_GRANT } from "~~/utils/eip712";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_GRANT, EIP_712_TYPES__REVIEW_GRANT_WITH_NOTE } from "~~/utils/eip712";
 import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 
 type ReqBody = {
@@ -11,7 +11,7 @@ type ReqBody = {
   action: ProposalStatusType;
   txHash: string;
   txChainId: string;
-  note: string;
+  note?: string;
 };
 
 export async function POST(req: NextRequest, { params }: { params: { grantId: string } }) {
@@ -25,20 +25,38 @@ export async function POST(req: NextRequest, { params }: { params: { grantId: st
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
   }
 
-  // Validate Signature
-  const recoveredAddress = await recoverTypedDataAddress({
-    domain: { ...EIP_712_DOMAIN, chainId: Number(txChainId) },
-    types: EIP_712_TYPES__REVIEW_GRANT,
-    primaryType: "Message",
-    message: {
-      grantId: grantId,
-      action: action,
-      txHash,
-      txChainId,
-      note,
-    },
-    signature,
-  });
+  let recoveredAddress: string;
+
+  // If action is approved or rejected, include note in signature
+  if (action === PROPOSAL_STATUS.APPROVED || action === PROPOSAL_STATUS.REJECTED) {
+    recoveredAddress = await recoverTypedDataAddress({
+      domain: { ...EIP_712_DOMAIN, chainId: Number(txChainId) },
+      types: EIP_712_TYPES__REVIEW_GRANT_WITH_NOTE,
+      primaryType: "Message",
+      message: {
+        grantId: grantId,
+        action: action,
+        txHash,
+        txChainId,
+        note: note ?? "",
+      },
+      signature,
+    });
+  } else {
+    // Validate Signature
+    recoveredAddress = await recoverTypedDataAddress({
+      domain: { ...EIP_712_DOMAIN, chainId: Number(txChainId) },
+      types: EIP_712_TYPES__REVIEW_GRANT,
+      primaryType: "Message",
+      message: {
+        grantId: grantId,
+        action: action,
+        txHash,
+        txChainId,
+      },
+      signature,
+    });
+  }
 
   if (recoveredAddress !== signer) {
     console.error("Signature error", recoveredAddress, signer);

--- a/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
+++ b/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
@@ -11,11 +11,12 @@ type ReqBody = {
   action: ProposalStatusType;
   txHash: string;
   txChainId: string;
+  note: string;
 };
 
 export async function POST(req: NextRequest, { params }: { params: { grantId: string } }) {
   const { grantId } = params;
-  const { signature, signer, action, txHash, txChainId } = (await req.json()) as ReqBody;
+  const { signature, signer, action, txHash, txChainId, note } = (await req.json()) as ReqBody;
 
   // Validate action is valid
   const validActions = Object.values(PROPOSAL_STATUS);
@@ -34,6 +35,7 @@ export async function POST(req: NextRequest, { params }: { params: { grantId: st
       action: action,
       txHash,
       txChainId,
+      note,
     },
     signature,
   });
@@ -56,6 +58,7 @@ export async function POST(req: NextRequest, { params }: { params: { grantId: st
       grantId,
       action,
       txHash,
+      note,
       txChainId,
     });
   } catch (error) {

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -56,7 +56,7 @@ const MyGrants: NextPage = () => {
             <div className="flex items-center">
               <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
               {grant.note && grant.note.trim().length > 0 && (
-                <div className="inline-block ml-1 tooltip pointer" data-tip={grant.note}>
+                <div className="inline-block ml-1 tooltip tooltip-bottom cursor-pointer" data-tip={grant.note}>
                   <QuestionMarkCircleIcon className="h-5 w-5 inline" />
                 </div>
               )}

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -55,8 +55,8 @@ const MyGrants: NextPage = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center">
               <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
-              {grant.approvedAt && (
-                <div className="inline-block ml-1 tooltip pointer" data-tip={grant.approvedNote}>
+              {grant.note && grant.note.trim().length > 0 && (
+                <div className="inline-block ml-1 tooltip pointer" data-tip={grant.note}>
                   <QuestionMarkCircleIcon className="h-5 w-5 inline" />
                 </div>
               )}

--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -7,6 +7,7 @@ import { NextPage } from "next";
 import useSWR from "swr";
 import { useAccount } from "wagmi";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
+import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
 import { GrantData } from "~~/services/database/schema";
 import { PROPOSAL_STATUS } from "~~/utils/grants";
 import { getBlockExplorerTxLink } from "~~/utils/scaffold-eth";
@@ -51,32 +52,41 @@ const MyGrants: NextPage = () => {
             </div>
           )}
           <p className="m-0">{grant.description}</p>
-          <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
-          {grant.approvedTx && (
-            <a
-              href={getBlockExplorerTxLink(Number(grant.txChainId), grant.approvedTx)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-4 underline underline-offset-4 text-xs"
-            >
-              50% approve tx <ArrowTopRightOnSquareIcon className="h-4 w-4 inline" />
-            </a>
-          )}
-          {grant.completedTx && (
-            <a
-              href={getBlockExplorerTxLink(Number(grant.txChainId), grant.completedTx)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-4 underline underline-offset-4 text-xs"
-            >
-              50% complete tx <ArrowTopRightOnSquareIcon className="h-4 w-4 inline" />
-            </a>
-          )}
-          {grant.status === PROPOSAL_STATUS.APPROVED && (
-            <button onClick={() => openModal(grant)} className="btn btn-primary float-right">
-              Submit build
-            </button>
-          )}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center">
+              <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
+              {grant.approvedAt && (
+                <div className="inline-block ml-1 tooltip pointer" data-tip={grant.approvedNote}>
+                  <QuestionMarkCircleIcon className="h-5 w-5 inline" />
+                </div>
+              )}
+              {grant.approvedTx && (
+                <a
+                  href={getBlockExplorerTxLink(Number(grant.txChainId), grant.approvedTx)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-4 underline underline-offset-4 text-xs"
+                >
+                  50% approve tx <ArrowTopRightOnSquareIcon className="h-4 w-4 inline" />
+                </a>
+              )}
+              {grant.completedTx && (
+                <a
+                  href={getBlockExplorerTxLink(Number(grant.txChainId), grant.completedTx)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-4 underline underline-offset-4 text-xs"
+                >
+                  50% complete tx <ArrowTopRightOnSquareIcon className="h-4 w-4 inline" />
+                </a>
+              )}
+            </div>
+            {grant.status === PROPOSAL_STATUS.APPROVED && (
+              <button onClick={() => openModal(grant)} className="btn btn-primary justify-self-end">
+                Submit build
+              </button>
+            )}
+          </div>
         </div>
       ))}
 

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -130,8 +130,9 @@ type ReviewGrantParams = {
   action: ProposalStatusType;
   txHash: string;
   txChainId: string;
+  note?: string;
 };
-export const reviewGrant = async ({ grantId, action, txHash, txChainId }: ReviewGrantParams) => {
+export const reviewGrant = async ({ grantId, action, txHash, txChainId, note }: ReviewGrantParams) => {
   try {
     const validActions = Object.values(PROPOSAL_STATUS);
     if (!validActions.includes(action)) {
@@ -139,19 +140,21 @@ export const reviewGrant = async ({ grantId, action, txHash, txChainId }: Review
     }
 
     // Prepare the data to update based on the action
-    const updateData: Record<string, any> = { status: action };
+    const updateData: Partial<GrantData> = { status: action };
 
     // Add/update the transaction hash based on the action
     if (action === PROPOSAL_STATUS.APPROVED) {
       updateData["approvedTx"] = txHash;
       updateData["txChainId"] = txChainId; // Add txChainId when the grant is approved
+      updateData["approvedNote"] = note && note.trim().length > 0 ? note : undefined;
     } else if (action === PROPOSAL_STATUS.COMPLETED) {
       updateData["completedTx"] = txHash;
+      updateData["completedNote"] = note && note.trim().length > 0 ? note : undefined;
     }
 
     // Update timestamp based on the action
     const grantActionTimeStamp = new Date().getTime();
-    const grantActionTimeStampKey = `${action}At`;
+    const grantActionTimeStampKey = `${action}At` as const;
     updateData[grantActionTimeStampKey] = grantActionTimeStamp;
 
     await grantsCollection.doc(grantId).update(updateData);

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -142,18 +142,16 @@ export const reviewGrant = async ({ grantId, action, txHash, txChainId, note }: 
     // Prepare the data to update based on the action
     const updateData: Partial<GrantData> = { status: action };
 
+    if (note !== undefined) {
+      updateData.note = note;
+    }
+
     // Add/update the transaction hash based on the action
     if (action === PROPOSAL_STATUS.APPROVED) {
       updateData["approvedTx"] = txHash;
       updateData["txChainId"] = txChainId; // Add txChainId when the grant is approved
-      if (note && note.trim().length > 0) {
-        updateData["approvedNote"] = note;
-      }
     } else if (action === PROPOSAL_STATUS.COMPLETED) {
       updateData["completedTx"] = txHash;
-      if (note && note.trim().length > 0) {
-        updateData["completedNote"] = note;
-      }
     }
 
     // Update timestamp based on the action

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -146,10 +146,14 @@ export const reviewGrant = async ({ grantId, action, txHash, txChainId, note }: 
     if (action === PROPOSAL_STATUS.APPROVED) {
       updateData["approvedTx"] = txHash;
       updateData["txChainId"] = txChainId; // Add txChainId when the grant is approved
-      updateData["approvedNote"] = note && note.trim().length > 0 ? note : undefined;
+      if (note && note.trim().length > 0) {
+        updateData["approvedNote"] = note;
+      }
     } else if (action === PROPOSAL_STATUS.COMPLETED) {
       updateData["completedTx"] = txHash;
-      updateData["completedNote"] = note && note.trim().length > 0 ? note : undefined;
+      if (note && note.trim().length > 0) {
+        updateData["completedNote"] = note;
+      }
     }
 
     // Update timestamp based on the action

--- a/packages/nextjs/services/database/schema.ts
+++ b/packages/nextjs/services/database/schema.ts
@@ -60,6 +60,8 @@ export type GrantWithoutTimestamps = {
   status: "proposed" | "approved" | "submitted" | "completed" | "rejected";
   approvedTx?: string;
   completedTx?: string;
+  approvedNote?: string;
+  completedNote?: string;
   txChainId?: string;
 };
 

--- a/packages/nextjs/services/database/schema.ts
+++ b/packages/nextjs/services/database/schema.ts
@@ -60,8 +60,7 @@ export type GrantWithoutTimestamps = {
   status: "proposed" | "approved" | "submitted" | "completed" | "rejected";
   approvedTx?: string;
   completedTx?: string;
-  approvedNote?: string;
-  completedNote?: string;
+  note?: string;
   txChainId?: string;
 };
 

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -19,15 +19,17 @@ export const EIP_712_TYPES__EDIT_GRANT = {
   ],
 } as const;
 
-const ReviewGrantMessage = [
-  { name: "grantId", type: "string" },
-  { name: "action", type: "string" },
-  { name: "txHash", type: "string" },
-  { name: "txChainId", type: "string" },
-] as const;
-
 export const EIP_712_TYPES__REVIEW_GRANT = {
-  Message: [...ReviewGrantMessage, { name: "note", type: "string" }],
+  Message: [
+    { name: "grantId", type: "string" },
+    { name: "action", type: "string" },
+    { name: "txHash", type: "string" },
+    { name: "txChainId", type: "string" },
+  ],
+} as const;
+
+export const EIP_712_TYPES__REVIEW_GRANT_WITH_NOTE = {
+  Message: [...EIP_712_TYPES__REVIEW_GRANT.Message, { name: "note", type: "string" }],
 } as const;
 
 export const EIP_712_TYPES__SUBMIT_GRANT = {
@@ -39,7 +41,7 @@ export const EIP_712_TYPES__SUBMIT_GRANT = {
 } as const;
 
 export const EIP_712_TYPES__REVIEW_GRANT_BATCH = {
-  GrantReview: ReviewGrantMessage,
+  GrantReview: EIP_712_TYPES__REVIEW_GRANT.Message,
   Message: [{ name: "reviews", type: "GrantReview[]" }],
 } as const;
 

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -19,13 +19,15 @@ export const EIP_712_TYPES__EDIT_GRANT = {
   ],
 } as const;
 
+const ReviewGrantMessage = [
+  { name: "grantId", type: "string" },
+  { name: "action", type: "string" },
+  { name: "txHash", type: "string" },
+  { name: "txChainId", type: "string" },
+] as const;
+
 export const EIP_712_TYPES__REVIEW_GRANT = {
-  Message: [
-    { name: "grantId", type: "string" },
-    { name: "action", type: "string" },
-    { name: "txHash", type: "string" },
-    { name: "txChainId", type: "string" },
-  ],
+  Message: [...ReviewGrantMessage, { name: "note", type: "string" }],
 } as const;
 
 export const EIP_712_TYPES__SUBMIT_GRANT = {
@@ -37,7 +39,7 @@ export const EIP_712_TYPES__SUBMIT_GRANT = {
 } as const;
 
 export const EIP_712_TYPES__REVIEW_GRANT_BATCH = {
-  GrantReview: [...EIP_712_TYPES__REVIEW_GRANT.Message],
+  GrantReview: ReviewGrantMessage,
   Message: [{ name: "reviews", type: "GrantReview[]" }],
 } as const;
 


### PR DESCRIPTION
## Description

#### Demo : 


https://github.com/BuidlGuidl/grants.buidlguidl.com/assets/80153681/ec06d002-c79c-4067-9da3-f72cfd539e15



#### Things handled : 
1. Admin can add note while rejecting grant 
2. Admin can add note while approving grant
3. User can see the note added by admin (tooltip)
4. ^ Not sure if tooltip is best suited of this if admin plans to write long notes maybe we could show modal with HTML tag `textarea` non-editable ? 

#### Things not handled / Kind of confused : 

1. How to handle adding of notes when doing batch operations (Umm maybe we can tell admin to fill note for each of grant we can create an extra modal similar to edit pencil icon and then admin clicks batch button) 
2. There is no way for admin to edit note once submitted (Where do we show this edit button ? Because Admin once mark the grant with approve / reject its gone from `/admin` until user mark their grant submitted)