### PR TITLE
Private notes

### DIFF
--- a/packages/nextjs/app/admin/_components/EditGrantModal.tsx
+++ b/packages/nextjs/app/admin/_components/EditGrantModal.tsx
@@ -136,10 +136,10 @@ export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>
           />
         </div>
         <div className="w-full flex-col gap-1">
-          <p className="m-0 font-semibold text-base">Private Note(optional)</p>
+          <p className="m-0 font-semibold text-base">Private Note (optional)</p>
           <textarea
             name="private_note"
-            placeholder="private note..."
+            placeholder="Notes for Admins"
             value={formData.private_note}
             className="textarea textarea-md textarea-bordered  w-full"
             rows={3}

--- a/packages/nextjs/app/admin/_components/EditGrantModal.tsx
+++ b/packages/nextjs/app/admin/_components/EditGrantModal.tsx
@@ -2,13 +2,13 @@ import { ChangeEvent, forwardRef, useState } from "react";
 import { useSWRConfig } from "swr";
 import useSWRMutation from "swr/mutation";
 import { useAccount, useNetwork, useSignTypedData } from "wagmi";
-import { GrantDataWithBuilder } from "~~/services/database/schema";
+import { GrantDataWithPrivateNote } from "~~/services/database/schema";
 import { EIP_712_DOMAIN, EIP_712_TYPES__EDIT_GRANT } from "~~/utils/eip712";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
 import { patchMutationFetcher } from "~~/utils/swr";
 
 type EditGrantModalProps = {
-  grant: GrantDataWithBuilder;
+  grant: GrantDataWithPrivateNote;
   closeModal: () => void;
 };
 
@@ -18,6 +18,7 @@ type ReqBody = {
   askAmount?: number;
   signature?: `0x${string}`;
   signer?: string;
+  private_note?: string;
 };
 
 export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>(({ grant, closeModal }, ref) => {
@@ -25,6 +26,7 @@ export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>
     title: grant.title,
     description: grant.description,
     askAmount: grant.askAmount.toString(),
+    private_note: grant.private_note ?? "",
   });
 
   const { address } = useAccount();
@@ -63,6 +65,7 @@ export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>
           // Converting this to number with parseFloat and again to string (similar to backend),
           // if not it generates different signature with .23 and 0.23
           askAmount: parseFloat(formData.askAmount).toString(),
+          private_note: formData.private_note,
         },
       });
       notificationId = notification.loading("Updating grant");
@@ -129,6 +132,17 @@ export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>
             placeholder="ask amount"
             value={formData.askAmount}
             className="input input-sm input-bordered w-full"
+            onChange={handleInputChange}
+          />
+        </div>
+        <div className="w-full flex-col gap-1">
+          <p className="m-0 font-semibold text-base">Private Note(optional)</p>
+          <textarea
+            name="privateNote"
+            placeholder="private note..."
+            value={formData.private_note}
+            className="textarea textarea-md textarea-bordered  w-full"
+            rows={3}
             onChange={handleInputChange}
           />
         </div>

--- a/packages/nextjs/app/admin/_components/EditGrantModal.tsx
+++ b/packages/nextjs/app/admin/_components/EditGrantModal.tsx
@@ -138,7 +138,7 @@ export const EditGrantModal = forwardRef<HTMLDialogElement, EditGrantModalProps>
         <div className="w-full flex-col gap-1">
           <p className="m-0 font-semibold text-base">Private Note(optional)</p>
           <textarea
-            name="privateNote"
+            name="private_note"
             placeholder="private note..."
             value={formData.private_note}
             className="textarea textarea-md textarea-bordered  w-full"

--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -11,7 +11,7 @@ import TelegramIcon from "~~/components/assets/TelegramIcon";
 import TwitterIcon from "~~/components/assets/TwitterIcon";
 import { Address } from "~~/components/scaffold-eth";
 import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
-import { GrantData, GrantDataWithBuilder, SocialLinks } from "~~/services/database/schema";
+import { GrantData, GrantDataWithPrivateNote, SocialLinks } from "~~/services/database/schema";
 import { PROPOSAL_STATUS, ProposalStatusType } from "~~/utils/grants";
 
 const BuilderSocials = ({ socialLinks }: { socialLinks?: SocialLinks }) => {
@@ -44,7 +44,7 @@ const BuilderSocials = ({ socialLinks }: { socialLinks?: SocialLinks }) => {
 };
 
 type GrantReviewProps = {
-  grant: GrantDataWithBuilder;
+  grant: GrantDataWithPrivateNote;
   selected: boolean;
   toggleSelection: () => void;
 };
@@ -220,6 +220,9 @@ export const GrantReview = ({ grant, selected, toggleSelection }: GrantReviewPro
             </button>
           </div>
         </div>
+        {grant.private_note && grant.private_note.trim().length > 0 && (
+          <p className="mb-0 text-orange-500">{grant.private_note}</p>
+        )}
       </div>
       <EditGrantModal ref={editGrantModalRef} grant={grant} closeModal={() => editGrantModalRef?.current?.close()} />
       <ActionModal ref={actionModalRef} grant={grant} initialTxLink={txResult?.hash} action={reviewAction} />

--- a/packages/nextjs/app/api/grants/[grantId]/route.ts
+++ b/packages/nextjs/app/api/grants/[grantId]/route.ts
@@ -18,15 +18,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { grantId: s
     const { grantId } = params;
     const { title, description, signature, signer, askAmount, private_note } = (await req.json()) as ReqBody;
 
-    if (
-      !title ||
-      !description ||
-      !askAmount ||
-      typeof askAmount !== "number" ||
-      !signature ||
-      !signer ||
-      !private_note
-    ) {
+    if (!title || !description || !askAmount || typeof askAmount !== "number" || !signature || !signer) {
       return NextResponse.json({ error: "Invalid form details submited" }, { status: 400 });
     }
 
@@ -34,7 +26,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { grantId: s
       domain: EIP_712_DOMAIN,
       types: EIP_712_TYPES__EDIT_GRANT,
       primaryType: "Message",
-      message: { title, description, askAmount: askAmount.toString(), grantId, private_note },
+      message: { title, description, askAmount: askAmount.toString(), grantId, private_note: private_note ?? "" },
       signature: signature,
     });
     if (recoveredAddress !== signer) {

--- a/packages/nextjs/app/api/grants/[grantId]/route.ts
+++ b/packages/nextjs/app/api/grants/[grantId]/route.ts
@@ -10,14 +10,23 @@ type ReqBody = {
   askAmount?: number;
   signature?: `0x${string}`;
   signer?: string;
+  private_note?: string;
 };
 
 export async function PATCH(req: NextRequest, { params }: { params: { grantId: string } }) {
   try {
     const { grantId } = params;
-    const { title, description, signature, signer, askAmount } = (await req.json()) as ReqBody;
+    const { title, description, signature, signer, askAmount, private_note } = (await req.json()) as ReqBody;
 
-    if (!title || !description || !askAmount || typeof askAmount !== "number" || !signature || !signer) {
+    if (
+      !title ||
+      !description ||
+      !askAmount ||
+      typeof askAmount !== "number" ||
+      !signature ||
+      !signer ||
+      !private_note
+    ) {
       return NextResponse.json({ error: "Invalid form details submited" }, { status: 400 });
     }
 
@@ -25,7 +34,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { grantId: s
       domain: EIP_712_DOMAIN,
       types: EIP_712_TYPES__EDIT_GRANT,
       primaryType: "Message",
-      message: { title, description, askAmount: askAmount.toString(), grantId },
+      message: { title, description, askAmount: askAmount.toString(), grantId, private_note },
       signature: signature,
     });
     if (recoveredAddress !== signer) {
@@ -37,8 +46,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { grantId: s
     if (signerData.data?.role !== "admin") {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-
-    await updateGrant(grantId, { title, description, askAmount });
+    await updateGrant(grantId, { title, description, askAmount }, private_note);
     return NextResponse.json({ success: true });
   } catch (e) {
     console.error(e);

--- a/packages/nextjs/services/database/schema.ts
+++ b/packages/nextjs/services/database/schema.ts
@@ -71,3 +71,4 @@ export type GrantData = Simplify<
 >;
 
 export type GrantDataWithBuilder = Simplify<GrantData & { builderData?: BuilderData }>;
+export type GrantDataWithPrivateNote = Simplify<GrantDataWithBuilder & { private_note?: string }>;

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -16,6 +16,7 @@ export const EIP_712_TYPES__EDIT_GRANT = {
 
     { name: "grantId", type: "string" },
     { name: "askAmount", type: "string" },
+    { name: "private_note", type: "string" },
   ],
 } as const;
 


### PR DESCRIPTION
## Description

<details>
    <summary>
      Reference videos in order:
    </summary>

- [Firestore subcollections](https://youtu.be/o7d5Zeic63s?si=pmmARyYEKMxKB7X8)
- [How to structure your data](https://youtu.be/haMOUb3KVSo?si=C0Y6WPzzG372qdi6)
- [Security rules(not that importan)](https://youtu.be/haMOUb3KVSo?si=C0Y6WPzzG372qdi6) 
    
</details>

<details>
  <summary>
    A bit about firebase sercurity rules which I didn't knew:
  </summary>
  
  
We create this rule in firestore console from firebase UI.

The security are useful when you are using firebase client SDK and don't have any server in between.

The security applied are bypassed when you are using firebase admin SDK.

^ Since firebase admin SDK is used in the server, it is assumed that the server is secure.

</details>

<details>
  <summary>
    Partial document retrieval is not supported in firebaseSDK:
  </summary>

When retrieving a document, all its data is fetched. You cannot omit some fields while getting a document in firebase sdk.

If we add a field called `privateNote` in document, it will be fetched with the document even if we don't need it.

So with the below code example:

```ts
// https://github.com/BuidlGuidl/grants.buidlguidl.com/blob/8998f332dd6cca166b887e72cd7d08f135521b0e/packages/nextjs/services/database/grants.ts#L41
// Function is called when retrieving grants for a builder (/my-grants)
const grantsSnapshot = await grantsCollection
  .where("builder", "==", userAddress)
  .get();
const grants: GrantData[] = [];
grantsSnapshot.forEach((doc) => {
  grants.push({ id: doc.id, ...doc.data() } as GrantData);
});
return grants;
// ^ [{id: "1", privateNote: "this is private note" ...}]
// privateNote will be present
```

</details>

-To solve above problem basically not getting `privateNote` field in grant doc, people seem to use subcollection since they are not at all shown when you retrive a grant doc. 

So yup as mentioned yesterday a way to solve #113 : 

1. Remove `privateNote` field manually from each grant on server before sending to grants for `api/builders/[builderAddress]/grants` / any endpoint expect admin

2. Using subcollection, because subcollections are not retrived when we query the parent collection.

3. Having a separate collection and refering its doc.id in grants document.

   - grant.privateNoteId: "djffdsfsd"
   - This way we can maintain one to one relationship, like each grant will have only one privateNote.
   - But again while retrieving a grant this `privateNoteId` will always be present and we need to manually remove like in 1.

The billing for 2. and 3. are the same (because they both will have same no of read in our case) 

But yeah 3. is the same as 1. in our case, since we have server in b/w and not direclty interacting with firebase through firebase client SDK

Hence went with option 2. (So no private note filed is shown when retreiving grant until we explictly query for it) and also this   didn't require updation to current api endpiont / function (like remove filed before sending from server) 

Demo : 


https://github.com/BuidlGuidl/grants.buidlguidl.com/assets/80153681/c8c7b5b2-450a-47d1-a2bb-ca7faf605963






