### PR TITLE
Admin tweaks - Delete stream badges and change logic for build submission rejections

### DIFF
--- a/packages/nextjs/app/admin/_components/ActionModal.tsx
+++ b/packages/nextjs/app/admin/_components/ActionModal.tsx
@@ -40,7 +40,7 @@ export const ActionModal = forwardRef<HTMLDialogElement, ActionModalProps>(({ gr
         </div>
         {action !== PROPOSAL_STATUS.REJECTED && (
           <div className="w-full flex-col space-y-1">
-            <p className="m-0 font-semibold text-base">Transction Hash</p>
+            <p className="m-0 font-semibold text-base">Transaction Hash</p>
             <input
               type="text"
               ref={transactionInputRef}

--- a/packages/nextjs/app/admin/_components/GrantReview.tsx
+++ b/packages/nextjs/app/admin/_components/GrantReview.tsx
@@ -170,12 +170,6 @@ export const GrantReview = ({ grant, selected, toggleSelection }: GrantReviewPro
               </a>
             );
           })}
-          {grant.builderData?.stream?.cap && (
-            <div className="badge badge-primary">
-              <span className="font-bold">Stream:&nbsp;</span>
-              {grant.builderData.stream.cap} ETH
-            </div>
-          )}
         </div>
       </div>
       <div className="p-4">

--- a/packages/nextjs/services/database/grants.ts
+++ b/packages/nextjs/services/database/grants.ts
@@ -146,6 +146,13 @@ export const reviewGrant = async ({ grantId, action, txHash, txChainId, note }: 
     // Prepare the data to update based on the action
     const updateData: Partial<GrantData> = { status: action };
 
+    // Reject build submission moving back to APPROVED status
+    const grantSnapshot = await getGrantSnapshotById(grantId);
+    const currentStatus = grantSnapshot.data()?.status;
+    if (currentStatus === PROPOSAL_STATUS.SUBMITTED && action === PROPOSAL_STATUS.REJECTED) {
+      updateData.status = PROPOSAL_STATUS.APPROVED;
+    }
+
     if (note !== undefined) {
       updateData.note = note;
     }


### PR DESCRIPTION
## Description

Couple of tweaks in /admin:

- When a grant is in approved status, users can submit their builds to be able to complete their grant and receive the rest of their grant amount (if admins approve the build proposal). 

  In case the build is not complete, and admins want to reject the build submissions, changed the logic of reject action, to change the status of the grant to "approved" instead of "rejected", so users can resubmit the build when they fix their problems. The condition I'm checking is if the current status of the grant prior executing the rejection logic was "submitted".
  
  The reject/approval notes were always showing in /my-grants for grants in approved status, so didn't need to tweak it.
  
  Closes #123


- Also deleted stream badges since regular streams don't exist anymore.

  Closes #124 