### PR TITLE
Add SpeedRun Ethereum completed challenges eligibility criteria to apply for a grant

### DIFF
--- a/packages/nextjs/app/_components/ApplyEligibilityLink.tsx
+++ b/packages/nextjs/app/_components/ApplyEligibilityLink.tsx
@@ -5,10 +5,18 @@ import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
 import { LockClosedIcon, LockOpenIcon } from "@heroicons/react/24/outline";
 import { useBGBuilderData } from "~~/hooks/useBGBuilderData";
+import { useSpeedRunChallengeEligibility } from "~~/hooks/useSpeedRunChallengeEligibility";
+import { REQUIRED_CHALLENGE_COUNT } from "~~/utils/eligibility-criteria";
 
 type BuilderStatus = "notConnected" | "notMember" | "eligible";
 
-const FeedbackMessage = ({ builderStatus }: { builderStatus: BuilderStatus }) => {
+const FeedbackMessage = ({
+  builderStatus,
+  completedChallengesCount,
+}: {
+  builderStatus: BuilderStatus;
+  completedChallengesCount?: number;
+}) => {
   if (builderStatus === "notConnected") {
     return (
       <div className="leading-snug">
@@ -22,10 +30,19 @@ const FeedbackMessage = ({ builderStatus }: { builderStatus: BuilderStatus }) =>
     return (
       <div className="leading-snug">
         <p className="-mb-2">
-          ❌ <strong>Not a BuidlGuidl member.</strong>
+          ❌ <strong>Not eligible.</strong>
         </p>
         <p>
-          Join by completing challenges at{" "}
+          You need to complete at least <strong>{REQUIRED_CHALLENGE_COUNT} SpeedRun Ethereum challenges</strong> to
+          apply for a grant.
+          <br />
+          {typeof completedChallengesCount === "number" && (
+            <span>
+              You have completed <strong>{completedChallengesCount}</strong> challenge
+              {completedChallengesCount === 1 ? "" : "s"}.
+            </span>
+          )}
+          <br />
           <a href="https://speedrunethereum.com" target="_blank" rel="noopener noreferrer" className="underline">
             speedrunethereum.com
           </a>
@@ -48,14 +65,27 @@ export const ApplyEligibilityLink = () => {
   const { isConnected, address: connectedAddress } = useAccount();
   const { isBuilderPresent, isLoading: isFetchingBuilderData } = useBGBuilderData(connectedAddress);
   const { openConnectModal } = useConnectModal();
+  const {
+    isLoading: isLoadingSRE,
+    isEligible: isEligibleSRE,
+    completedChallengesCount,
+  } = useSpeedRunChallengeEligibility(connectedAddress);
 
-  const builderStatus: BuilderStatus =
-    !isConnected || isFetchingBuilderData ? "notConnected" : !isBuilderPresent ? "notMember" : "eligible";
+  let builderStatus: BuilderStatus = "notConnected";
+  if (!isConnected || isLoadingSRE) {
+    builderStatus = "notConnected";
+  } else if (isEligibleSRE || isBuilderPresent) {
+    builderStatus = "eligible";
+  } else {
+    builderStatus = "notMember";
+  }
+
+  const isFetching = isLoadingSRE || (isEligibleSRE === false && isFetchingBuilderData);
 
   return (
     <div className="mx-auto lg:m-0 flex flex-col items-start bg-white px-6 py-2 pb-6 font-spaceGrotesk space-y-1 w-4/5 rounded-2xl text-left">
       <p className="text-2xl font-semibold mb-0">Do you qualify?</p>
-      <FeedbackMessage builderStatus={builderStatus} />
+      <FeedbackMessage builderStatus={builderStatus} completedChallengesCount={completedChallengesCount} />
       {builderStatus === "eligible" ? (
         <Link
           href="/apply"
@@ -73,7 +103,7 @@ export const ApplyEligibilityLink = () => {
             if (!isConnected && openConnectModal) openConnectModal();
           }}
         >
-          {isFetchingBuilderData ? (
+          {isFetching ? (
             <span className="loading loading-spinner h-5 w-5"></span>
           ) : (
             <LockClosedIcon className="h-5 w-5 mr-1 inline-block" />

--- a/packages/nextjs/app/apply/_component/SubmitButton.tsx
+++ b/packages/nextjs/app/apply/_component/SubmitButton.tsx
@@ -3,27 +3,37 @@
 import { useFormStatus } from "react-dom";
 import { useAccount } from "wagmi";
 import { useBGBuilderData } from "~~/hooks/useBGBuilderData";
+import { useSpeedRunChallengeEligibility } from "~~/hooks/useSpeedRunChallengeEligibility";
+import { REQUIRED_CHALLENGE_COUNT } from "~~/utils/eligibility-criteria";
 
 // To use useFormStatus we need to make sure button is child of form
 const SubmitButton = () => {
   const { pending } = useFormStatus();
   const { isConnected, address: connectedAddress } = useAccount();
   const { isBuilderPresent, isLoading: isFetchingBuilderData } = useBGBuilderData(connectedAddress);
-  const isSubmitDisabled = !isConnected || isFetchingBuilderData || pending || !isBuilderPresent;
+  const {
+    isLoading: isLoadingSRE,
+    isEligible: isEligibleSRE,
+    completedChallengesCount,
+  } = useSpeedRunChallengeEligibility(connectedAddress);
+
+  const isEligible = isEligibleSRE || isBuilderPresent;
+  const isFetching = isLoadingSRE || (isEligibleSRE === false && isFetchingBuilderData);
+  const isSubmitDisabled = !isConnected || isFetching || !isEligible || pending;
+
+  let tooltip = "";
+  if (!isConnected) {
+    tooltip = "Please connect your wallet";
+  } else if (!isEligible) {
+    tooltip = `You need to complete at least ${REQUIRED_CHALLENGE_COUNT} SpeedRun Ethereum challenges to submit a grant${
+      typeof completedChallengesCount === "number" ? `. You have completed ${completedChallengesCount}.` : "."
+    }`;
+  }
 
   return (
-    <div
-      className={`flex ${(!isConnected || !isBuilderPresent) && "tooltip tooltip-bottom"}`}
-      data-tip={`${
-        !isConnected
-          ? "Please connect your wallet"
-          : !isBuilderPresent
-          ? "You should be a buidlguidl builder to submit grant"
-          : ""
-      }`}
-    >
+    <div className={`flex ${(!isConnected || !isEligible) && "tooltip tooltip-bottom"}`} data-tip={tooltip}>
       <button className="btn btn-primary w-full" disabled={isSubmitDisabled} aria-disabled={isSubmitDisabled}>
-        {(isFetchingBuilderData || pending) && <span className="loading loading-spinner loading-md"></span>}
+        {(isFetching || pending) && <span className="loading loading-spinner loading-md"></span>}
         Submit
       </button>
     </div>

--- a/packages/nextjs/hooks/useSpeedRunChallengeEligibility.ts
+++ b/packages/nextjs/hooks/useSpeedRunChallengeEligibility.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { REQUIRED_CHALLENGE_COUNT, fetchAcceptedChallengeCount } from "~~/utils/eligibility-criteria";
+
+export const useSpeedRunChallengeEligibility = (address?: string) => {
+  const [completedChallengesCount, setCompletedCount] = useState<number>(0);
+  const [isEligible, setIsEligible] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    if (!address) return;
+    setIsLoading(true);
+    fetchAcceptedChallengeCount(address)
+      .then(count => {
+        setCompletedCount(count);
+        setIsEligible(count >= REQUIRED_CHALLENGE_COUNT);
+        setIsLoading(false);
+      })
+      .catch(err => {
+        setError(err);
+        setIsLoading(false);
+      });
+  }, [address]);
+
+  return { isLoading, error, completedChallengesCount, isEligible };
+};

--- a/packages/nextjs/utils/eligibility-criteria.ts
+++ b/packages/nextjs/utils/eligibility-criteria.ts
@@ -1,0 +1,13 @@
+export const REQUIRED_CHALLENGE_COUNT = 5;
+
+export async function fetchAcceptedChallengeCount(address: string): Promise<number> {
+  if (!address) return 0;
+  try {
+    const res = await fetch(`https://speedrunethereum.com/api/user-challenges/${address}`);
+    if (!res.ok) return 0;
+    const data = await res.json();
+    return data.challenges?.filter((ch: any) => ch.reviewAction === "ACCEPTED").length ?? 0;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
Adding eligibility logic checking SRE challenge count (>=5), maintaining legacy BG builders logic, for old builders that did not need 5 challenges to join BG.

Changes made:

- Made a shared util to fetch and count accepted SRE challenges, used by both frontend (hook) and backend (not sure if that's the correct approach!)
- Added frontend hook and updated UI and tooltips to use the new logic and show live challenge count, in both the homepage and `/apply` page (submission button). 
- Backend `/api/grants/new` now checks SRE challenges too, not just BG membership
- Using `REQUIRED_CHALLENGE_COUNT` in `packages/nextjs/utils/eligibility-criteria.ts` for the required challenge count