### PR TITLE
Add link to the build when submitted or completed

### DIFF
--- a/packages/nextjs/app/my-grants/page.tsx
+++ b/packages/nextjs/app/my-grants/page.tsx
@@ -55,6 +55,17 @@ const MyGrants: NextPage = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center">
               <p className={`badge ${badgeBgColor[grant.status]}`}>{grant.status}</p>
+              {(grant.status === PROPOSAL_STATUS.SUBMITTED || grant.status === PROPOSAL_STATUS.COMPLETED) &&
+                grant.link && (
+                  <a
+                    href={grant.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-2 text-blue-600 underline underline-offset-4 text-xs align-middle font-bold"
+                  >
+                    view build <ArrowTopRightOnSquareIcon className="h-4 w-4 inline" />
+                  </a>
+                )}
               {grant.note &&
                 grant.note.trim().length > 0 &&
                 (grant.status === PROPOSAL_STATUS.REJECTED || grant.status === PROPOSAL_STATUS.APPROVED) && (


### PR DESCRIPTION
In `my-grants`, users weren’t able to open the linked build (after they submitted it for grant completion, or when the grant was completed)

On the `homepage`, we already let users open the build from Completed grants using the "Learn more" button, but that wasn’t available in `my-grants`.

This PR fixes that. It could be even nicer once we add a visual grant tag to SRE builds that are linked to a BG grant, will create an issue to discuss it in SRE repo 🙏
