### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/packages/local_db/seed.sample.json
+++ b/packages/local_db/seed.sample.json
@@ -119,7 +119,7 @@
       "videoUrl": "",
       "desc": "👩‍🏫 Learn how to build on Ethereum completing the scaffold-eth challenges.",
       "image": "https://storage.googleapis.com/download/storage/v1/b/buidlguidl-v3.appspot.com/o/builds%2F0032da28a08871cbcb2922b00.png?generation=1647284971917513&alt=media",
-      "name": "🏃‍♀️ SpeedRunEthereum.com",
+      "name": "🏃‍♀️ Speedrun Ethereum.com",
       "builder": "0x60583563D5879C2E59973E5718c7DE2147971807",
       "featured": false,
       "submittedTimestamp": 1658587661752,
@@ -280,7 +280,7 @@
       "payload": {
         "userAddress": "0x60583563D5879C2E59973E5718c7DE2147971807",
         "buildUrl": "https://github.com/moonshotcollective/scaffold-directory",
-        "name": "🏃‍♀️ SpeedRunEthereum.com",
+        "name": "🏃‍♀️ Speedrun Ethereum.com",
         "buildId": "06bb3c9d-784b-44d1-b7e2-1ae5affdfa8b"
       }
     },

--- a/packages/nextjs/app/_components/ApplyEligibilityLink.tsx
+++ b/packages/nextjs/app/_components/ApplyEligibilityLink.tsx
@@ -32,7 +32,7 @@ const FeedbackMessage = ({
           ❌ <strong>Not eligible.</strong>
         </p>
         <p>
-          You need to complete at least <strong>{REQUIRED_CHALLENGE_COUNT} SpeedRun Ethereum challenges</strong> to
+          You need to complete at least <strong>{REQUIRED_CHALLENGE_COUNT} Speedrun Ethereum challenges</strong> to
           apply for a grant.
           <br />
           <span>

--- a/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
+++ b/packages/nextjs/app/api/grants/[grantId]/review/route.tsx
@@ -122,7 +122,7 @@ export async function POST(req: NextRequest, { params }: { params: { grantId: st
           }
         } catch (sreError) {
           // Log SRE errors but don't fail the main operation
-          console.error("[SRE] Error notifying SpeedRunEthereum:", sreError);
+          console.error("[SRE] Error notifying Speedrun Ethereum:", sreError);
         }
       })(),
     );

--- a/packages/nextjs/app/api/grants/new/route.ts
+++ b/packages/nextjs/app/api/grants/new/route.ts
@@ -23,12 +23,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid form details submitted" }, { status: 400 });
     }
 
-    // Legacy BG builder presence check removed. All eligibility is now based on the new SpeedRunEthereum system. If needed we could try do some kind of ROLE validation and make sure OG BuidlGuidl members that that certain ROLE in new SRE database.
+    // Legacy BG builder presence check removed. All eligibility is now based on the new Speedrun Ethereum system. If needed we could try do some kind of ROLE validation and make sure OG BuidlGuidl members that that certain ROLE in new SRE database.
     const completed = await fetchAcceptedChallengeCount(signer);
     if (completed < REQUIRED_CHALLENGE_COUNT) {
       return NextResponse.json(
         {
-          error: `Only builders with at least ${REQUIRED_CHALLENGE_COUNT} accepted SpeedRun Ethereum challenges can submit for grants`,
+          error: `Only builders with at least ${REQUIRED_CHALLENGE_COUNT} accepted Speedrun Ethereum challenges can submit for grants`,
         },
         { status: 401 },
       );

--- a/packages/nextjs/app/apply/_component/SubmitButton.tsx
+++ b/packages/nextjs/app/apply/_component/SubmitButton.tsx
@@ -17,7 +17,7 @@ const SubmitButton = () => {
   if (!isConnected) {
     tooltip = "Please connect your wallet";
   } else if (!isEligible) {
-    tooltip = `You need to complete at least ${REQUIRED_CHALLENGE_COUNT} SpeedRun Ethereum challenges to submit a grant${
+    tooltip = `You need to complete at least ${REQUIRED_CHALLENGE_COUNT} Speedrun Ethereum challenges to submit a grant${
       typeof completedChallengesCount === "number" ? `. You have completed ${completedChallengesCount}.` : "."
     }`;
   }

--- a/packages/nextjs/app/my-grants/_components/SubmitModal.tsx
+++ b/packages/nextjs/app/my-grants/_components/SubmitModal.tsx
@@ -90,9 +90,9 @@ export const SubmitModal = ({ grant, closeModal }: { grant: GrantData; closeModa
               rel="noopener noreferrer"
               className="text-black-500 underline"
             >
-              SpeedRun Ethereum profile
+              Speedrun Ethereum profile
             </a>
-            &nbsp;and then submit the URL of your SpeedRun Ethereum build in this form. BG Grants team will review it to
+            &nbsp;and then submit the URL of your Speedrun Ethereum build in this form. BG Grants team will review it to
             complete the grant.
           </span>
         </div>


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links

## Description

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
